### PR TITLE
Add partial payment logic and warnings

### DIFF
--- a/booking-confirmation.html
+++ b/booking-confirmation.html
@@ -26,6 +26,7 @@
             <div class="text-green-500 text-6xl mb-2">✔️</div>
             <h1 class="text-2xl font-bold">Booking Confirmed!</h1>
             <p class="text-gray-600 mt-2">Thank you for booking with Calma Car Rental. A confirmation email has been sent.</p>
+            <p id="paymentThankYou" class="text-gray-700 mt-1">Thank you for your payment! Your booking is complete.</p>
             <div id="bookingReference" class="mt-4 text-sm text-gray-500">
                 Booking Reference: <span id="booking-ref" class="font-semibold text-black">Loading...</span>
             </div>
@@ -46,8 +47,9 @@
                 <h2 class="text-lg font-semibold mb-2">Payment Summary</h2>
                 <p><strong>Car:</strong> <span id="carInfo">Loading...</span></p>
                 <p><strong>Daily Rate:</strong> <span id="dailyRate">Loading...</span></p>
-                <p><strong>Total Amount:</strong> <span id="totalPrice" class="font-semibold">Loading...</span></p>
-                <p><strong>Payment Status:</strong> <span class="text-green-600 font-semibold">To be paid at pick-up</span></p>
+                <p><strong>Total Rental Price:</strong> <span id="totalPrice" class="font-semibold">Loading...</span></p>
+                <p><strong>You have paid:</strong> <span id="partialPaid">Loading...</span> via Stripe</p>
+                <p><strong>Remaining Balance:</strong> <span id="remainingBalance" class="font-semibold text-red-600">Loading...</span> to be paid at pickup</p>
             </div>
         </div>
         
@@ -160,6 +162,12 @@
                 document.getElementById('carInfo').textContent = `${rental.car_make} ${rental.car_model}`;
                 document.getElementById('dailyRate').textContent = formatCurrency(rental.daily_rate);
                 document.getElementById('totalPrice').textContent = formatCurrency(rental.total_price);
+                const stored = JSON.parse(localStorage.getItem('currentBooking') || '{}');
+                const total = parseFloat(rental.total_price) || 0;
+                const partial = stored.partialAmount ? (stored.partialAmount).toFixed(2) : (total * 0.45).toFixed(2);
+                const remaining = (total - parseFloat(partial)).toFixed(2);
+                document.getElementById('partialPaid').textContent = `€${partial}`;
+                document.getElementById('remainingBalance').textContent = `€${remaining}`;
                 
                 // Calculate rental duration in days
                 if (rental.pickup_date && rental.return_date) {

--- a/payment.html
+++ b/payment.html
@@ -243,17 +243,26 @@
               <span id="options">Loading...</span>
             </div>
             <div class="total-row">
-              <span>Total Amount:</span>
+              <span>Total Rental Price:</span>
               <span id="total-amount">Loading...</span>
+            </div>
+            <div class="summary-row">
+              <span><strong>You Pay Now (45%):</strong></span>
+              <span id="partial-amount">Loading...</span>
+            </div>
+            <div class="summary-row">
+              <span><strong>Remaining Balance:</strong></span>
+              <span id="remaining-amount">Loading...</span>
             </div>
           </div>
         </div>
-        
+
         <div class="payment-methods text-center">
           <p class="mb-3">100% secure payment powered by <i class="fab fa-cc-stripe"></i> Stripe</p>
           <button id="pay-button" class="btn btn-primary btn-lg">
             <i class="fas fa-lock me-2"></i>Pay Now
           </button>
+          <p style="margin-top:0.5rem;font-size:0.9rem;color:#555;">By continuing, you agree to pay the remaining balance in person when picking up the car.</p>
         </div>
       </div>
     </div>
@@ -275,9 +284,13 @@
             throw new Error('Missing booking data');
           }
 
+          const partialAmount = Math.round(bookingData.totalPrice * 0.45);
+          bookingData.partialAmount = partialAmount;
+          localStorage.setItem('currentBooking', JSON.stringify(bookingData));
+
           const bookingDetails = {
             bookingReference: bookingData.bookingReference,
-            totalAmount: bookingData.totalPrice,
+            totalPrice: bookingData.totalPrice,
             carName: bookingData.selectedCar ? `${bookingData.selectedCar.make} ${bookingData.selectedCar.model}` : 'Car',
             startDate: bookingData.pickupDate,
             endDate: bookingData.returnDate
@@ -286,7 +299,7 @@
           const response = await fetch('/api/create-checkout-session', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ bookingDetails })
+            body: JSON.stringify({ bookingDetails: { ...bookingDetails, partialAmount } })
           });
 
           const data = await response.json();
@@ -335,7 +348,12 @@
           }
           document.getElementById('options').textContent = options;
           if (bookingData.totalPrice) {
-            document.getElementById('total-amount').textContent = `€${bookingData.totalPrice.toFixed(2)}`;
+            const total = bookingData.totalPrice;
+            const partial = (total * 0.45).toFixed(2);
+            const remaining = (total - partial).toFixed(2);
+            document.getElementById('total-amount').textContent = `€${total.toFixed(2)}`;
+            document.getElementById('partial-amount').textContent = `€${partial}`;
+            document.getElementById('remaining-amount').textContent = `€${remaining} – to be paid at pickup`;
           }
         } catch (e) {
           console.error('Failed to load booking summary', e);

--- a/personal-info.html
+++ b/personal-info.html
@@ -1278,6 +1278,9 @@
           <input type="checkbox" id="termsAccepted" name="termsAccepted" required>
           <label for="termsAccepted">I agree to the <a href="#" id="terms-link">Terms and Conditions</a> and <a href="#">Privacy Policy</a></label>
         </div>
+        <p style="color:#555;font-size:0.95rem;margin-top:0.5rem;">
+          Note: Only <strong>45%</strong> of the total rental price will be paid online. The remaining <strong>55%</strong> must be paid in person when picking up the car.
+        </p>
         <div id="termsAccepted-error" class="validation-message"></div>
       </div>
       

--- a/server.js
+++ b/server.js
@@ -1620,13 +1620,13 @@ app.delete('/api/admin/manual-block/:id', requireAdminAuth, async (req, res) => 
 app.post('/api/create-checkout-session', async (req, res) => {
   try {
     const { bookingDetails } = req.body;
-    if (!bookingDetails || !bookingDetails.carName || !bookingDetails.totalAmount) {
+    if (!bookingDetails || !bookingDetails.carName || !bookingDetails.partialAmount) {
       return res.status(400).json({ error: 'Missing required booking details' });
     }
 
-    const { carName, totalAmount, startDate, endDate, bookingReference } = bookingDetails;
+    const { carName, partialAmount, startDate, endDate, bookingReference } = bookingDetails;
 
-    if (totalAmount < MIN_CHARGE_AMOUNT) {
+    if (partialAmount < MIN_CHARGE_AMOUNT) {
       return res.status(400).json({ error: `Amount must be at least €${MIN_CHARGE_AMOUNT.toFixed(2)}` });
     }
     const description = startDate && endDate ? `Rental: ${startDate} to ${endDate}` : undefined;
@@ -1645,7 +1645,7 @@ app.post('/api/create-checkout-session', async (req, res) => {
               name: carName,
               description: description || '',
             },
-            unit_amount: Math.round(totalAmount * 100),
+            unit_amount: Math.round(partialAmount * 100),
           },
           quantity: 1,
         },


### PR DESCRIPTION
## Summary
- show notice that only 45% is paid online in Personal Info page
- display payment breakdown on Payment page and note about balance
- send only 45% of rental price to Stripe
- adjust server route to use partialAmount
- show paid/remaining amounts on booking confirmation with thank‑you message

## Testing
- `node tests/mobileSidebar.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6841c3a176088332af45e14176d3a02d