### PR TITLE
Show payment breakdown in booking modal

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -600,10 +600,14 @@ function formatTimestamp(isoString) {
 
 function showBookingDetails(booking) {
     if (!bookingDetailsContent) return;
-    
+
     const statusClass = getStatusClass(booking.status);
     const formattedDate = formatTimestamp(booking.createdAt);
-    
+    const totalPrice = parseFloat(booking.total_price || booking.totalPrice);
+    const formattedTotalPrice = isNaN(totalPrice) ? 'N/A' : `€${totalPrice.toFixed(2)}`;
+    const paid = isNaN(totalPrice) ? 'N/A' : `€${(totalPrice * 0.45).toFixed(2)}`;
+    const due = isNaN(totalPrice) ? 'N/A' : `€${(totalPrice * 0.55).toFixed(2)}`;
+
     bookingDetailsContent.innerHTML = `
         <div class="booking-details-header">
             <h5 class="mb-0">Booking Details</h5>
@@ -620,7 +624,9 @@ function showBookingDetails(booking) {
                     <div class="col-md-6">
                         <p><strong>Pickup Date:</strong> ${new Date(booking.pickup_date).toLocaleDateString()}</p>
                         <p><strong>Return Date:</strong> ${new Date(booking.return_date).toLocaleDateString()}</p>
-                        <p><strong>Total Price:</strong> $${booking.total_price}</p>
+                        <p><strong>Total Price:</strong> ${formattedTotalPrice}</p>
+                        <p><strong style="color: green;">Paid:</strong> ${paid}</p>
+                        <p><strong style="color: red;">Due:</strong> ${due}</p>
                     </div>
                 </div>
             </div>

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1052,9 +1052,14 @@ function showBookingDetails(booking) {
     
     // Extract pricing - handle missing or zero data
     const dailyRate = parseFloat(booking.daily_rate);
-    const totalPrice = parseFloat(booking.total_price);
+    const totalPrice = parseFloat(booking.total_price || booking.totalPrice);
     const formattedDailyRate = isNaN(dailyRate) ? 'N/A' : formatCurrency(dailyRate);
     const formattedTotalPrice = isNaN(totalPrice) ? 'N/A' : formatCurrency(totalPrice);
+
+    const paidAmount = isNaN(totalPrice) ? null : (totalPrice * 0.45).toFixed(2);
+    const dueAmount = isNaN(totalPrice) ? null : (totalPrice * 0.55).toFixed(2);
+    const formattedPaid = paidAmount ? `€${paidAmount}` : 'N/A';
+    const formattedDue = dueAmount ? `€${dueAmount}` : 'N/A';
     
     // Extra options
     const childSeat = booking.child_seat || false;
@@ -1133,6 +1138,12 @@ function showBookingDetails(booking) {
                     </div>
                     <div class="col-md-6 mb-2">
                         <strong>Total Price:</strong> ${formattedTotalPrice}
+                    </div>
+                    <div class="col-md-6 mb-2">
+                        <strong style="color: green;">Paid:</strong> ${formattedPaid}
+                    </div>
+                    <div class="col-md-6 mb-2">
+                        <strong style="color: red;">Due:</strong> ${formattedDue}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add payment breakdown in `showBookingDetails` logic
- display paid and due amounts in booking detail modal

## Testing
- `node tests/mobileSidebar.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6841d488f0e483328ebe03ea5bc2c571