### PR TITLE
Add terms modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -339,6 +339,83 @@
                 width: 90%;
             }
         }
+
+        /* Terms & Conditions Modal Styles */
+        #terms-modal.modal {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.7);
+            z-index: 1000;
+        }
+
+        #terms-modal .modal-content {
+            background: white;
+            margin: 10% auto;
+            padding: 2rem;
+            width: 80%;
+            max-width: 700px;
+            border-radius: 12px;
+            max-height: 80%;
+            overflow-y: auto;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+            animation: modalFadeIn 0.3s ease;
+        }
+
+        #terms-modal .close-modal {
+            float: right;
+            font-size: 28px;
+            cursor: pointer;
+            color: #999;
+            transition: color 0.2s ease;
+        }
+
+        #terms-modal .close-modal:hover {
+            color: #333;
+        }
+
+        #terms-modal h2 {
+            color: #0066cc;
+            margin-bottom: 1.5rem;
+            font-size: 1.8rem;
+            position: relative;
+            padding-bottom: 0.5rem;
+        }
+
+        #terms-modal h2::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 60px;
+            height: 3px;
+            background-color: #0066cc;
+            border-radius: 3px;
+        }
+
+        #terms-modal h3 {
+            color: #444;
+            margin: 1.5rem 0 0.75rem;
+            font-size: 1.2rem;
+        }
+
+        #terms-modal p,
+        #terms-modal li {
+            margin-bottom: 1rem;
+            line-height: 1.6;
+            color: #555;
+        }
+
+        @media (max-width: 768px) {
+            #terms-modal .modal-content {
+                padding: 1.5rem;
+                margin: 15% auto;
+                width: 90%;
+            }
+        }
         
         @media (max-width: 600px) {
             h1 {
@@ -1155,7 +1232,7 @@
                     <ul>
                         <li><a href="#about">About Us</a></li>
                         <li><a href="#cars">Our Fleet</a></li>
-                        <li><a href="#additional">Terms & Conditions</a></li>
+                        <li><a href="#" id="terms-link">Terms & Conditions</a></li>
                     </ul>
                 </div>
                 
@@ -1250,6 +1327,73 @@
 
                 <h3>11. Contact</h3>
                 <p>For privacy inquiries, contact us at <strong>calmarental@gmail.com</strong>.</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Terms & Conditions Modal -->
+    <div id="terms-modal" class="modal">
+        <div class="modal-content">
+            <span class="close-modal">&times;</span>
+            <h2>Terms & Conditions</h2>
+            <div class="terms-content">
+                <h3>1. Introduction</h3>
+                <p>These Terms &amp; Conditions govern the rental agreement between Calma Car Rental ("we," "us," or "our") and the customer ("you" or "your"). By booking a vehicle with us, you agree to comply with these terms.</p>
+
+                <h3>2. Rental Requirements</h3>
+                <ul>
+                    <li>Minimum age: Renters must be at least 25 years old.</li>
+                    <li>Driver's license: A valid driver's license held for at least 12 months is required.</li>
+                    <li>Additional drivers: Only drivers listed in the rental agreement may operate the vehicle.</li>
+                </ul>
+
+                <h3>3. Booking &amp; Payment</h3>
+                <ul>
+                    <li>We accept major credit cards and cash in Euro.</li>
+                    <li>Prepayment may be required for some bookings.</li>
+                    <li>Free cancellation is allowed up to 48 hours before pickup.</li>
+                </ul>
+
+                <h3>4. Pickup and Return</h3>
+                <ul>
+                    <li>Free delivery/pickup at Chania Airport, Port, City Center, and nearby hotels/villas.</li>
+                    <li>Late drop-offs after 8:00 PM incur a &euro;10 surcharge.</li>
+                    <li>Vehicles must be returned in the same condition with a full tank.</li>
+                </ul>
+
+                <h3>5. Use of the Vehicle</h3>
+                <ul>
+                    <li>Not allowed for off-road driving, towing, or illegal activities.</li>
+                    <li>Use is restricted to Crete unless approved in writing.</li>
+                </ul>
+
+                <h3>6. Insurance and Liability</h3>
+                <ul>
+                    <li>Basic insurance is included.</li>
+                    <li>Additional coverage is available.</li>
+                    <li>Accidents must be reported immediately with a police report.</li>
+                </ul>
+
+                <h3>7. Customer Responsibilities</h3>
+                <ul>
+                    <li>You are responsible for all traffic fines and penalties.</li>
+                    <li>Take care of the vehicle and lock it when unattended.</li>
+                </ul>
+
+                <h3>8. Company Rights</h3>
+                <ul>
+                    <li>We may substitute your vehicle with a similar or better model.</li>
+                    <li>We reserve the right to terminate the rental if terms are violated.</li>
+                </ul>
+
+                <h3>9. Privacy and Data Use</h3>
+                <p>Your data is handled in accordance with our Privacy Policy.</p>
+
+                <h3>10. Governing Law and Jurisdiction</h3>
+                <p>These terms are governed by Greek law. Any disputes will be handled by the courts of Chania.</p>
+
+                <h3>11. Contact</h3>
+                <p>If you have questions, contact us at:<br><strong>Email</strong>: calmarental@gmail.com<br><strong>Phone</strong>: +30 6942 515267</p>
             </div>
         </div>
     </div>
@@ -1364,7 +1508,11 @@
         document.addEventListener('DOMContentLoaded', function() {
             const privacyLink = document.getElementById('privacy-policy-link');
             const privacyModal = document.getElementById('privacy-modal');
-            const closeModal = privacyModal.querySelector('.close-modal');
+            const privacyClose = privacyModal.querySelector('.close-modal');
+
+            const termsLink = document.getElementById('terms-link');
+            const termsModal = document.getElementById('terms-modal');
+            const termsClose = termsModal.querySelector('.close-modal');
 
             if (privacyLink) {
                 privacyLink.addEventListener('click', function(e) {
@@ -1373,15 +1521,31 @@
                 });
             }
 
-            if (closeModal) {
-                closeModal.addEventListener('click', function() {
+            if (privacyClose) {
+                privacyClose.addEventListener('click', function() {
                     privacyModal.style.display = 'none';
+                });
+            }
+
+            if (termsLink) {
+                termsLink.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    termsModal.style.display = 'block';
+                });
+            }
+
+            if (termsClose) {
+                termsClose.addEventListener('click', function() {
+                    termsModal.style.display = 'none';
                 });
             }
 
             window.addEventListener('click', function(event) {
                 if (event.target === privacyModal) {
                     privacyModal.style.display = 'none';
+                }
+                if (event.target === termsModal) {
+                    termsModal.style.display = 'none';
                 }
             });
         });


### PR DESCRIPTION
## Summary
- add Terms & Conditions modal styling and HTML
- allow clicking footer link to open modal
- extend modal script to handle privacy and terms modals

## Testing
- `npm install`
- `node tests/mobileSidebar.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6841db7e6bc48332a1e11f7ddd43fc39