### PR TITLE
Secure CORS settings

### DIFF
--- a/server.js
+++ b/server.js
@@ -37,8 +37,15 @@ const FRONTEND_URL = process.env.FRONTEND_URL || `http://localhost:${port}`;
 // Stripe requires a minimum amount of 0.50 EUR
 const MIN_CHARGE_AMOUNT = 0.5;
 
+// CORS configuration
+const ALLOWED_ORIGIN = 'https://calmarental.com';
+const corsOptions = {
+    origin: ALLOWED_ORIGIN,
+    credentials: true,
+};
+
 // Middleware
-app.use(cors());
+app.use(cors(corsOptions));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());


### PR DESCRIPTION
## Summary
- lock down CORS to `https://calmarental.com` and enable credentials

## Testing
- `node tests/mobileSidebar.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6841e4b556b0833289027b4173726764