### PR TITLE
Fix undefined 'query' import

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ const cookieParser = require('cookie-parser');
 const session = require('express-session');
 const { v4: uuidv4 } = require('uuid');
 const bcrypt = require('bcrypt');
-const { body, param, validationResult } = require('express-validator');
+const { body, param, query, validationResult } = require('express-validator');
 const xss = require('xss');
 require('dotenv').config();
 


### PR DESCRIPTION
## Summary
- include `query` from express-validator in server.js

## Testing
- `node tests/mobileSidebar.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68428ba7c88883328dcb15474d3a0324