### PR TITLE
Fix email sending on booking

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,12 @@ CREATE TABLE IF NOT EXISTS cars (
 )
 ```
 
-The `monthly_pricing` field stores a JSON object with prices for each month of the year. 
+The `monthly_pricing` field stores a JSON object with prices for each month of the year.
+
+## Email Notifications
+
+The server sends booking confirmation emails using [Resend](https://resend.com/).
+Set the following environment variables to enable emails:
+
+- `RESEND_API_KEY` – your Resend API key
+- `ADMIN_NOTIFICATION_EMAIL` – optional address that receives a copy of every booking confirmation


### PR DESCRIPTION
## Summary
- send email to customer when a new booking is created
- optionally send copy to admin via `ADMIN_NOTIFICATION_EMAIL`
- document Resend configuration in README

## Testing
- `npm install`
- `node tests/mobileSidebar.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6842a42df0c08332a211cdcbbea52eab