### PR TITLE
Improve admin login UX

### DIFF
--- a/admin-login.html
+++ b/admin-login.html
@@ -55,8 +55,8 @@
             <div class="card-body p-4">
                 <form id="loginForm">
                     <div class="mb-3">
-                        <label for="username" class="form-label">Username</label>
-                        <input type="text" class="form-control" id="username" required>
+                        <label for="email" class="form-label">Email</label>
+                        <input type="email" class="form-control" id="email" required>
                     </div>
                     <div class="mb-3">
                         <label for="password" class="form-label">Password</label>
@@ -92,18 +92,26 @@
 
             loginForm.addEventListener("submit", async (e) => {
                 e.preventDefault();
-                const username = document.getElementById("username").value;
+                errorMessage.style.display = "none";
+                const email = document.getElementById("email").value;
                 const password = document.getElementById("password").value;
-                const res = await fetch("/api/admin/login", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    credentials: "include",
-                    body: JSON.stringify({ username, password })
-                });
-                if (res.ok) {
-                    window.location.href = "admin.html";
-                } else {
-                    errorMessage.textContent = "Invalid username or password";
+                try {
+                    const res = await fetch("/admin/login", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        credentials: "include",
+                        body: JSON.stringify({ email, password })
+                    });
+                    const data = await res.json();
+                    if (res.ok && data.success) {
+                        localStorage.setItem('adminToken', 'session');
+                        window.location.href = "admin.html";
+                    } else {
+                        errorMessage.textContent = data.message || 'Invalid login';
+                        errorMessage.style.display = "block";
+                    }
+                } catch (err) {
+                    errorMessage.textContent = 'Network error. Please try again.';
                     errorMessage.style.display = "block";
                 }
             });


### PR DESCRIPTION
## Summary
- handle network errors when logging in
- store a session token in localStorage to satisfy existing admin.js logic
- add admin login route and update session middleware
- ensure newline at end of admin-login.html

## Testing
- `npm install`
- `node tests/mobileSidebar.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6842d85f6e108332a11c42433e82c6e4