### PR TITLE
Fix session cookie issue behind proxy

### DIFF
--- a/docs/README-RAILWAY-SETUP.md
+++ b/docs/README-RAILWAY-SETUP.md
@@ -70,6 +70,10 @@ Setting up the database will:
 - **Bookings not appearing**: Check your server logs on Railway for any errors
 - **Database connection issues**: Verify your `DATABASE_URL` environment variable is correct
 - **Server errors**: Check that all required dependencies are installed
+- **Admin session cookie not set**: When hosting behind a reverse proxy
+  (e.g. Railway's HTTPS layer or Cloudflare), make sure the server trusts the
+  proxy so secure cookies can be issued. The code now calls
+  `app.set('trust proxy', 1)`; redeploy if you updated from an earlier version.
 
 If you encounter issues, look at the browser's developer console and your Railway logs for error messages.
 

--- a/server.js
+++ b/server.js
@@ -51,6 +51,8 @@ const corsOptions = {
 
 // Middleware
 app.use(cors(corsOptions));
+// Trust the first proxy when behind load balancers or reverse proxies
+app.set('trust proxy', 1);
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());


### PR DESCRIPTION
## Summary
- ensure Express trusts the first proxy so secure cookies are set
- document this requirement in Railway deployment notes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843e5690d048332a2a8de7fdd75798a