### PR TITLE
Delay confirmation email until payment

### DIFF
--- a/server.js
+++ b/server.js
@@ -499,7 +499,6 @@ app.post('/api/bookings',
 
         if (insertResult.rows && insertResult.rows.length > 0) {
             await syncManualBlockWithBooking(insertResult.rows[0]);
-            await sendBookingConfirmationEmail(insertResult.rows[0]);
         }
 
         return res.status(200).json({


### PR DESCRIPTION
## Summary
- send booking confirmation email only after a booking is completed

## Testing
- `npm install`
- `node tests/mobileSidebar.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6843ff04170c8332ae920f42d2c31f2a