### PR TITLE
Fix booking confirmation emails

### DIFF
--- a/server.js
+++ b/server.js
@@ -499,6 +499,7 @@ app.post('/api/bookings',
 
         if (insertResult.rows && insertResult.rows.length > 0) {
             await syncManualBlockWithBooking(insertResult.rows[0]);
+            await sendBookingConfirmationEmail(insertResult.rows[0]);
         }
 
         return res.status(200).json({


### PR DESCRIPTION
## Summary
- send booking confirmation immediately after saving a new booking

## Testing
- `npm install`
- `node tests/mobileSidebar.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684419067cdc83329450177ecc48b8cd