### PR TITLE
Add booking confirmation template via Resend

### DIFF
--- a/emails/BookingConfirmation.jsx
+++ b/emails/BookingConfirmation.jsx
@@ -1,0 +1,39 @@
+import { Html } from '@react-email/html';
+import { Head } from '@react-email/head';
+import { Preview } from '@react-email/preview';
+
+export default function BookingConfirmation({ data }) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Your Calma Car Rental booking confirmation</Preview>
+      <body style={{ fontFamily: 'Arial, sans-serif', backgroundColor: '#f4f4f4', padding: '40px 0' }}>
+        <table width="100%" cellPadding="0" cellSpacing="0" style={{ maxWidth: '600px', margin: '0 auto', backgroundColor: '#ffffff', borderRadius: '8px', overflow: 'hidden', boxShadow: '0 0 10px rgba(0,0,0,0.1)' }}>
+          <tr>
+            <td style={{ backgroundColor: '#4b125c', padding: '20px', textAlign: 'center' }}>
+              <img src="https://calmarental.com/images/CalmaLogo.jpg" alt="Calma Logo" style={{ maxWidth: '160px' }} />
+            </td>
+          </tr>
+          <tr>
+            <td style={{ padding: '30px 20px' }}>
+              <h2 style={{ color: '#4b125c' }}>Booking Confirmation</h2>
+              <p><strong>Reference:</strong> {data.reference}</p>
+              <p><strong>Car:</strong> {data.car}</p>
+              <p><strong>Pickup Date:</strong> {data.pickup}</p>
+              <p><strong>Return Date:</strong> {data.return}</p>
+              <hr style={{ border: 'none', borderTop: '1px solid #ccc', margin: '20px 0' }} />
+              <p><strong>Total Price:</strong> €{data.total}</p>
+              <p><strong>Paid Amount (45%):</strong> €{data.paid}</p>
+              <p><strong>Due at Pickup (55%):</strong> €{data.due}</p>
+            </td>
+          </tr>
+          <tr>
+            <td style={{ backgroundColor: '#f4f4f4', padding: '20px', textAlign: 'center', fontSize: '12px', color: '#888' }}>
+              Thank you for choosing Calma Car Rental. Safe travels!
+            </td>
+          </tr>
+        </table>
+      </body>
+    </Html>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,15 @@
     "resend": "^4.5.2",
     "stripe": "^18.2.1",
     "uuid": "^11.1.0",
-    "xss": "^1.0.15"
+    "xss": "^1.0.15",
+    "@react-email/html": "^0.0.11",
+    "@react-email/head": "^0.0.12",
+    "@react-email/preview": "^0.0.13",
+    "@react-email/render": "^1.1.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "esbuild": "^0.25.5",
+    "esbuild-register": "^3.6.0"
   },
   "engines": {
     "node": ">=16.0.0"


### PR DESCRIPTION
## Summary
- integrate JSX template `BookingConfirmation.jsx` with Resend
- register `esbuild-register` to compile email components on the fly
- install React and React Email packages

## Testing
- `npm install`
- `node tests/mobileSidebar.test.js`


------
https://chatgpt.com/codex/tasks/task_e_684483bd9d808332a4b97fb056171266