### PR TITLE
Add booking confirmation template via Resend

### DIFF
--- a/emails/BookingConfirmation.jsx
+++ b/emails/BookingConfirmation.jsx
@@ -1,0 +1,39 @@
+import { Html } from '@react-email/html';
+import { Head } from '@react-email/head';
+import { Preview } from '@react-email/preview';
+
+export default function BookingConfirmation({ data }) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Your Calma Car Rental booking confirmation</Preview>
+      <body style={{ fontFamily: 'Arial, sans-serif', backgroundColor: '#f4f4f4', padding: '40px 0' }}>
+        <table width="100%" cellPadding="0" cellSpacing="0" style={{ maxWidth: '600px', margin: '0 auto', backgroundColor: '#ffffff', borderRadius: '8px', overflow: 'hidden', boxShadow: '0 0 10px rgba(0,0,0,0.1)' }}>
+          <tr>
+            <td style={{ backgroundColor: '#4b125c', padding: '20px', textAlign: 'center' }}>
+              <img src="https://calmarental.com/images/CalmaLogo.jpg" alt="Calma Logo" style={{ maxWidth: '160px' }} />
+            </td>
+          </tr>
+          <tr>
+            <td style={{ padding: '30px 20px' }}>
+              <h2 style={{ color: '#4b125c' }}>Booking Confirmation</h2>
+              <p><strong>Reference:</strong> {data.reference}</p>
+              <p><strong>Car:</strong> {data.car}</p>
+              <p><strong>Pickup Date:</strong> {data.pickup}</p>
+              <p><strong>Return Date:</strong> {data.return}</p>
+              <hr style={{ border: 'none', borderTop: '1px solid #ccc', margin: '20px 0' }} />
+              <p><strong>Total Price:</strong> €{data.total}</p>
+              <p><strong>Paid Amount (45%):</strong> €{data.paid}</p>
+              <p><strong>Due at Pickup (55%):</strong> €{data.due}</p>
+            </td>
+          </tr>
+          <tr>
+            <td style={{ backgroundColor: '#f4f4f4', padding: '20px', textAlign: 'center', fontSize: '12px', color: '#888' }}>
+              Thank you for choosing Calma Car Rental. Safe travels!
+            </td>
+          </tr>
+        </table>
+      </body>
+    </Html>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,15 @@
     "resend": "^4.5.2",
     "stripe": "^18.2.1",
     "uuid": "^11.1.0",
-    "xss": "^1.0.15"
+    "xss": "^1.0.15",
+    "@react-email/html": "^0.0.11",
+    "@react-email/head": "^0.0.12",
+    "@react-email/preview": "^0.0.13",
+    "@react-email/render": "^1.1.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "esbuild": "^0.25.5",
+    "esbuild-register": "^3.6.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/server.js
+++ b/server.js
@@ -13,9 +13,18 @@ const { v4: uuidv4 } = require('uuid');
 const bcrypt = require('bcrypt');
 const { body, param, query, validationResult } = require('express-validator');
 const xss = require('xss');
+require('dotenv').config();
+
 const { Resend } = require('resend');
 const resend = new Resend(process.env.RESEND_API_KEY);
-require('dotenv').config();
+
+// Register JSX support for React email templates
+const { register } = require('esbuild-register/dist/node');
+register({ extensions: ['.jsx'] });
+
+const React = require('react');
+const { render } = require('@react-email/render');
+const BookingConfirmationEmail = require('./emails/BookingConfirmation.jsx').default;
 
 // Ensure the Stripe secret key is provided
 if (!process.env.STRIPE_SECRET_KEY) {
@@ -499,8 +508,8 @@ app.post('/api/bookings',
 
         if (insertResult.rows && insertResult.rows.length > 0) {
             await syncManualBlockWithBooking(insertResult.rows[0]);
-            // Confirmation email is now sent only after successful payment
-            // during the /confirm-payment flow.
+            // Immediately notify the customer of the pending booking
+            await sendBookingConfirmationEmail(insertResult.rows[0]);
         }
 
         return res.status(200).json({
@@ -1483,20 +1492,25 @@ async function sendBookingConfirmationEmail(booking) {
             recipients.push(process.env.ADMIN_NOTIFICATION_EMAIL);
         }
 
+        const html = await render(
+            React.createElement(BookingConfirmationEmail, {
+                data: {
+                    reference: booking.booking_reference,
+                    car: `${booking.car_make} ${booking.car_model}`,
+                    pickup: booking.pickup_date,
+                    return: booking.return_date,
+                    total,
+                    paid,
+                    due
+                }
+            })
+        );
+
         await resend.emails.send({
             from: 'Calma Car Rental <booking@calmarental.com>',
             to: recipients,
             subject: 'Your Booking Confirmation – Calma Car Rental',
-            html: `
-                <h1>Booking Confirmation</h1>
-                <p>Reference: <strong>${booking.booking_reference}</strong></p>
-                <p>Car: <strong>${booking.car_make} ${booking.car_model}</strong></p>
-                <p>Pickup Date: ${booking.pickup_date}</p>
-                <p>Return Date: ${booking.return_date}</p>
-                <p>Total Price: €${total}</p>
-                <p>Paid Amount (45%): €${paid}</p>
-                <p>Due at Pickup (55%): €${due}</p>
-            `
+            html
         });
         console.log(`📧 Confirmation email sent to ${recipients.join(', ')}`);
     } catch (err) {


### PR DESCRIPTION
## Summary
- integrate JSX template `BookingConfirmation.jsx` with Resend
- register `esbuild-register` to compile email components on the fly
- install React and React Email packages
- send a confirmation email immediately after creating a booking
- load environment variables before instantiating the Resend client

## Testing
- `npm install`
- `node tests/mobileSidebar.test.js`


------
https://chatgpt.com/codex/tasks/task_e_684483bd9d808332a4b97fb056171266