### PR TITLE
Improve Resend email handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,7 +16,8 @@ const xss = require('xss');
 require('dotenv').config();
 
 const { Resend } = require('resend');
-const resend = new Resend(process.env.RESEND_API_KEY);
+const resendApiKey = process.env.RESEND_API_KEY;
+const resend = resendApiKey ? new Resend(resendApiKey) : null;
 
 // Register JSX support for React email templates
 const { register: esbuildRegister } = require('esbuild-register/dist/node');
@@ -1477,10 +1478,11 @@ async function calculateTotalPrice(car_id, pickup_date, return_date) {
 
 // Send booking confirmation email using Resend
 async function sendBookingConfirmationEmail(booking) {
-    if (!process.env.RESEND_API_KEY) {
+    if (!resend) {
         console.warn('RESEND_API_KEY not configured; skipping email');
         return;
     }
+    console.log(`Sending confirmation email for booking ${booking.booking_reference}`);
     if (!booking || !booking.customer_email) return;
     try {
         const total = parseFloat(booking.total_price || 0);


### PR DESCRIPTION
## Summary
- handle missing RESEND_API_KEY without crashing server
- log when confirmation emails are sent

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68449189c6148332a2122f66294f5564