### PR TITLE
Improve mobile layout

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -200,38 +200,42 @@ body.dark-mode a:hover {
     html {
         font-size: 14px;
     }
-    
+
     section {
-        padding: 40px 0;
+        padding: 35px 0;
     }
-    
+
     .section-header {
-        margin-bottom: 30px;
+        margin-bottom: 25px;
     }
 }
 
 @media (max-width: 480px) {
     html {
-        font-size: 13px;
+        font-size: 12px;
     }
-    
+
     h1 {
-        font-size: 2rem;
+        font-size: 1.6rem;
     }
-    
+
     h2 {
-        font-size: 1.75rem;
+        font-size: 1.4rem;
     }
-    
+
     h3 {
-        font-size: 1.3rem;
+        font-size: 1.1rem;
     }
-    
+
     section {
-        padding: 30px 0;
+        padding: 20px 0;
     }
-    
+
     .container {
-        padding: 0 10px;
+        padding: 0 5px;
     }
-} 
+
+    .section-header {
+        margin-bottom: 20px;
+    }
+}

--- a/assets/css/booking.css
+++ b/assets/css/booking.css
@@ -401,32 +401,32 @@ body.dark-mode .confirmation-message {
 
 @media (max-width: 480px) {
     .booking-form {
-        padding: 15px 10px;
+        padding: 10px 8px;
     }
     
     .form-row {
-        margin: 0 -5px 15px;
+        margin: 0 -5px 10px;
     }
     
     .form-group {
         padding: 0 5px;
-        margin-bottom: 10px;
+        margin-bottom: 8px;
     }
     
     .btn {
-        padding: 8px 15px;
-        font-size: 0.9rem;
+        padding: 6px 12px;
+        font-size: 0.85rem;
     }
     
     .step {
-        width: 30px;
-        height: 30px;
-        margin: 0 20px;
+        width: 26px;
+        height: 26px;
+        margin: 0 15px;
     }
     
     .step-title {
-        width: 60px;
-        font-size: 0.75rem;
+        width: 55px;
+        font-size: 0.7rem;
     }
 }
 

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -159,4 +159,22 @@
     .mobile-menu {
         display: block;
     }
-} 
+}
+
+@media (max-width: 480px) {
+    .site-header {
+        padding: 8px 0;
+    }
+
+    .logo img {
+        height: 32px;
+    }
+
+    .nav-links li {
+        margin: 10px 0;
+    }
+
+    .nav-links a {
+        font-size: 1rem;
+    }
+}

--- a/assets/css/hero.css
+++ b/assets/css/hero.css
@@ -59,30 +59,30 @@ body.dark-mode .hero {
 /* Media Queries */
 @media (max-width: 768px) {
     .hero {
-        padding: 120px 0 60px;
-        min-height: 450px;
+        padding: 100px 0 50px;
+        min-height: 420px;
     }
-    
+
     .hero h1 {
-        font-size: 2.5rem;
+        font-size: 2.2rem;
     }
-    
+
     .hero p {
-        font-size: 1.1rem;
+        font-size: 1rem;
     }
 }
 
 @media (max-width: 480px) {
     .hero {
-        padding: 100px 0 50px;
-        min-height: 400px;
+        padding: 80px 0 40px;
+        min-height: 360px;
     }
-    
+
     .hero h1 {
-        font-size: 2rem;
+        font-size: 1.6rem;
     }
-    
+
     .hero p {
-        font-size: 1rem;
+        font-size: 0.9rem;
     }
-} 
+}


### PR DESCRIPTION
## Summary
- adjust responsive base styles for smaller fonts and tighter spacing
- refine header spacing for very small screens
- tweak hero sizing for phone widths
- tighten booking form layout on mobile

## Testing
- `npm install`
- `node tests/mobileSidebar.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6844e0e9e49c833291f783b1622635c8