### PR TITLE
Improve mobile layout

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -752,6 +752,62 @@
             background-position: right calc(0.375em + 0.1875rem) center;
             background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
         }
+
+        /* Extra small screens tweaks */
+        @media (max-width: 480px) {
+            html {
+                font-size: 12px;
+            }
+
+            .mobile-navbar {
+                padding: 0.5rem 0.8rem;
+            }
+
+            .mobile-navbar .navbar-title {
+                font-size: 1rem;
+            }
+
+            .mobile-sidebar {
+                width: 85vw;
+                padding: 1rem 0.8rem;
+            }
+
+            .mobile-sidebar .nav-link {
+                font-size: 0.9rem;
+                padding: 0.6rem 0.8rem;
+                margin-bottom: 0.6rem;
+            }
+
+            .container-fluid, .row, .col-md-9, .col-lg-10, .px-md-4 {
+                padding: 0.5rem !important;
+            }
+
+            .card, .card-stats, .card-revenue, .card-bookings, .card-cars {
+                font-size: 0.9rem !important;
+                padding: 0.8rem !important;
+            }
+
+            .card-title, .h2 {
+                font-size: 0.95rem !important;
+            }
+
+            .bottom-nav {
+                height: 55px;
+            }
+
+            .bottom-nav .nav-btn {
+                font-size: 1rem;
+            }
+
+            body {
+                padding-bottom: 65px !important;
+                font-size: 13px !important;
+            }
+
+            .filter-section {
+                padding: 0.6rem;
+            }
+        }
     </style>
 </head>
 <body>

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -200,38 +200,42 @@ body.dark-mode a:hover {
     html {
         font-size: 14px;
     }
-    
+
     section {
-        padding: 40px 0;
+        padding: 35px 0;
     }
-    
+
     .section-header {
-        margin-bottom: 30px;
+        margin-bottom: 25px;
     }
 }
 
 @media (max-width: 480px) {
     html {
-        font-size: 13px;
+        font-size: 12px;
     }
-    
+
     h1 {
-        font-size: 2rem;
+        font-size: 1.6rem;
     }
-    
+
     h2 {
-        font-size: 1.75rem;
+        font-size: 1.4rem;
     }
-    
+
     h3 {
-        font-size: 1.3rem;
+        font-size: 1.1rem;
     }
-    
+
     section {
-        padding: 30px 0;
+        padding: 20px 0;
     }
-    
+
     .container {
-        padding: 0 10px;
+        padding: 0 5px;
     }
-} 
+
+    .section-header {
+        margin-bottom: 20px;
+    }
+}

--- a/assets/css/booking.css
+++ b/assets/css/booking.css
@@ -401,32 +401,32 @@ body.dark-mode .confirmation-message {
 
 @media (max-width: 480px) {
     .booking-form {
-        padding: 15px 10px;
+        padding: 10px 8px;
     }
     
     .form-row {
-        margin: 0 -5px 15px;
+        margin: 0 -5px 10px;
     }
     
     .form-group {
         padding: 0 5px;
-        margin-bottom: 10px;
+        margin-bottom: 8px;
     }
     
     .btn {
-        padding: 8px 15px;
-        font-size: 0.9rem;
+        padding: 6px 12px;
+        font-size: 0.85rem;
     }
     
     .step {
-        width: 30px;
-        height: 30px;
-        margin: 0 20px;
+        width: 26px;
+        height: 26px;
+        margin: 0 15px;
     }
     
     .step-title {
-        width: 60px;
-        font-size: 0.75rem;
+        width: 55px;
+        font-size: 0.7rem;
     }
 }
 

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -159,4 +159,22 @@
     .mobile-menu {
         display: block;
     }
-} 
+}
+
+@media (max-width: 480px) {
+    .site-header {
+        padding: 8px 0;
+    }
+
+    .logo img {
+        height: 32px;
+    }
+
+    .nav-links li {
+        margin: 10px 0;
+    }
+
+    .nav-links a {
+        font-size: 1rem;
+    }
+}

--- a/assets/css/hero.css
+++ b/assets/css/hero.css
@@ -59,30 +59,30 @@ body.dark-mode .hero {
 /* Media Queries */
 @media (max-width: 768px) {
     .hero {
-        padding: 120px 0 60px;
-        min-height: 450px;
+        padding: 100px 0 50px;
+        min-height: 420px;
     }
-    
+
     .hero h1 {
-        font-size: 2.5rem;
+        font-size: 2.2rem;
     }
-    
+
     .hero p {
-        font-size: 1.1rem;
+        font-size: 1rem;
     }
 }
 
 @media (max-width: 480px) {
     .hero {
-        padding: 100px 0 50px;
-        min-height: 400px;
+        padding: 80px 0 40px;
+        min-height: 360px;
     }
-    
+
     .hero h1 {
-        font-size: 2rem;
+        font-size: 1.6rem;
     }
-    
+
     .hero p {
-        font-size: 1rem;
+        font-size: 0.9rem;
     }
-} 
+}

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -39,6 +39,50 @@ body {
     padding: 0 15px;
 }
 
+@media (max-width: 768px) {
+    html {
+        font-size: 14px;
+    }
+
+    section {
+        padding: 35px 0;
+    }
+
+    .section-header {
+        margin-bottom: 25px;
+    }
+}
+
+@media (max-width: 480px) {
+    html {
+        font-size: 12px;
+    }
+
+    h1 {
+        font-size: 1.6rem;
+    }
+
+    h2 {
+        font-size: 1.4rem;
+    }
+
+    h3 {
+        font-size: 1.1rem;
+    }
+
+    section {
+        padding: 20px 0;
+    }
+
+    .container {
+        padding: 0 5px;
+    }
+
+    .section-header {
+        margin-bottom: 20px;
+    }
+}
+
 /* Header & Navigation */
 header {
     background-color: rgba(255, 255, 255, 0.95);
@@ -105,6 +149,24 @@ header {
     display: none;
     font-size: 24px;
     cursor: pointer;
+}
+
+@media (max-width: 480px) {
+    header {
+        padding: 8px 0;
+    }
+
+    .logo img {
+        height: 32px;
+    }
+
+    .nav-links li {
+        margin: 10px 0;
+    }
+
+    .nav-links a {
+        font-size: 1rem;
+    }
 }
 
 /* Hero Section */
@@ -904,11 +966,18 @@ footer {
 
 @media (max-width: 768px) {
     .hero {
-        padding-top: 100px !important;
-        padding-bottom: 120px !important;
-        min-height: auto !important;
+        padding: 100px 0 50px;
+        min-height: 420px;
     }
-    
+
+    .hero h1 {
+        font-size: 2.2rem;
+    }
+
+    .hero p {
+        font-size: 1rem;
+    }
+
     .hero-content {
         padding-top: 20px !important;
         width: 100% !important;
@@ -1015,6 +1084,50 @@ footer {
     
     .booking-form {
         margin-top: 60px;
+    }
+}
+
+@media (max-width: 480px) {
+    .hero {
+        padding: 80px 0 40px;
+        min-height: 360px;
+    }
+
+    .hero h1 {
+        font-size: 1.6rem;
+    }
+
+    .hero p {
+        font-size: 0.9rem;
+    }
+
+    .booking-form {
+        padding: 10px 8px;
+    }
+
+    .form-row {
+        margin: 0 -5px 10px;
+    }
+
+    .form-group {
+        padding: 0 5px;
+        margin-bottom: 8px;
+    }
+
+    .btn {
+        padding: 6px 12px;
+        font-size: 0.85rem;
+    }
+
+    .step {
+        width: 26px;
+        height: 26px;
+        margin: 0 15px;
+    }
+
+    .step-title {
+        width: 55px;
+        font-size: 0.7rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- compile mobile styling tweaks into main stylesheet
- adjust global font sizes and section spacing on small screens
- shrink header elements for phones
- refine hero and booking form styling for narrow widths
- apply extra small-screen adjustments on the admin page

## Testing
- `npm install`
- `node tests/mobileSidebar.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6844e0e9e49c833291f783b1622635c8