### PR TITLE
Remove duplicate late surcharge message

### DIFF
--- a/index.html
+++ b/index.html
@@ -739,7 +739,6 @@
                                 
                                 <!-- Late surcharge message - updated for 8PM -->
   <div class="late-surcharge" style="display: none; margin-top: 5px; font-size: 0.85rem; color: #dc3545; background-color: #f8d7da; padding: 5px 10px; border-radius: 4px;">
-                                    <i class="fas fa-exclamation-circle"></i> A late return surcharge of €10 applies for drop-offs after 8:00 PM.
                                     <i class="fas fa-exclamation-circle"></i> A late return surcharge of €5 per hour applies for drop-offs after 8:00 PM.
                                 </div>
                                 


### PR DESCRIPTION
## Summary
- remove the outdated "€10" late surcharge text from *index.html*

## Testing
- `node tests/mobileSidebar.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68459f7e3ca08332975b3f8e95ecae4a