### PR TITLE
Fix admin login path

### DIFF
--- a/server.js
+++ b/server.js
@@ -109,7 +109,13 @@ const validate = (validations) => async (req, res, next) => {
     }
     next();
 };
-app.get("/admin.html", requireAdminAuth, (req, res) => res.sendFile(path.join(__dirname, "admin.html")));
+app.get("/admin.html", requireAdminAuth, (req, res) =>
+  res.sendFile(path.join(__dirname, "admin.html"))
+);
+// Serve the login page when requesting /admin-login.html for consistency
+app.get("/admin-login.html", (req, res) =>
+  res.sendFile(path.join(__dirname, "admin-login.html"))
+);
 
 // Serve static files
 // Expose only the intended public directories


### PR DESCRIPTION
## Summary
- serve `/admin-login.html` directly

## Testing
- `npm install`
- `node tests/mobileSidebar.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68468baab44c83329d86f78c7864217c