### PR TITLE
Adjust deposit calc to exclude addons

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1041,8 +1041,14 @@ function showBookingDetails(booking) {
     const formattedDailyRate = isNaN(dailyRate) ? 'N/A' : formatCurrency(dailyRate);
     const formattedTotalPrice = isNaN(totalPrice) ? 'N/A' : formatCurrency(totalPrice);
 
-    const paidAmount = isNaN(totalPrice) ? null : (totalPrice * 0.45).toFixed(2);
-    const dueAmount = isNaN(totalPrice) ? null : (totalPrice * 0.55).toFixed(2);
+    let paidAmount = null;
+    let dueAmount = null;
+    if (!isNaN(totalPrice) && !isNaN(dailyRate)) {
+        const days = Math.ceil((new Date(booking.return_date) - new Date(booking.pickup_date)) / (1000 * 60 * 60 * 24)) + 1;
+        const base = dailyRate * days;
+        paidAmount = (base * 0.45).toFixed(2);
+        dueAmount = (totalPrice - parseFloat(paidAmount)).toFixed(2);
+    }
     const formattedPaid = paidAmount ? `€${paidAmount}` : 'N/A';
     const formattedDue = dueAmount ? `€${dueAmount}` : 'N/A';
     

--- a/booking-confirmation.html
+++ b/booking-confirmation.html
@@ -180,7 +180,14 @@
                 document.getElementById('totalPrice').textContent = formatCurrency(rental.total_price);
                 const stored = JSON.parse(localStorage.getItem('currentBooking') || '{}');
                 const total = parseFloat(rental.total_price) || 0;
-                const partial = stored.partialAmount ? (stored.partialAmount).toFixed(2) : (total * 0.45).toFixed(2);
+                let partial;
+                if (stored.partialAmount) {
+                    partial = parseFloat(stored.partialAmount).toFixed(2);
+                } else {
+                    const days = Math.ceil((new Date(rental.return_date) - new Date(rental.pickup_date)) / (1000*60*60*24)) + 1;
+                    const base = (parseFloat(rental.daily_rate) || 0) * days;
+                    partial = (base * 0.45).toFixed(2);
+                }
                 const remaining = (total - parseFloat(partial)).toFixed(2);
                 document.getElementById('partialPaid').textContent = `€${partial}`;
                 document.getElementById('remainingBalance').textContent = `€${remaining}`;

--- a/payment.html
+++ b/payment.html
@@ -284,7 +284,10 @@
             throw new Error('Missing booking data');
           }
 
-          const partialAmount = Math.round(bookingData.totalPrice * 0.45);
+          const basePrice = bookingData.selectedCar && bookingData.durationDays
+            ? bookingData.selectedCar.price * bookingData.durationDays
+            : bookingData.totalPrice;
+          const partialAmount = Math.round(basePrice * 0.45);
           bookingData.partialAmount = partialAmount;
           localStorage.setItem('currentBooking', JSON.stringify(bookingData));
 
@@ -348,9 +351,12 @@
           }
           document.getElementById('options').textContent = options;
           if (bookingData.totalPrice) {
+            const base = bookingData.selectedCar && bookingData.durationDays
+              ? bookingData.selectedCar.price * bookingData.durationDays
+              : bookingData.totalPrice;
             const total = bookingData.totalPrice;
-            const partial = (total * 0.45).toFixed(2);
-            const remaining = (total - partial).toFixed(2);
+            const partial = (base * 0.45).toFixed(2);
+            const remaining = (total - parseFloat(partial)).toFixed(2);
             document.getElementById('total-amount').textContent = `€${total.toFixed(2)}`;
             document.getElementById('partial-amount').textContent = `€${partial}`;
             document.getElementById('remaining-amount').textContent = `€${remaining} – to be paid at pickup`;

--- a/server.js
+++ b/server.js
@@ -1490,8 +1490,12 @@ async function sendBookingConfirmationEmail(booking) {
     if (!booking || !booking.customer_email) return;
     try {
         const total = parseFloat(booking.total_price || 0);
-        const paid = (total * 0.45).toFixed(2);
-        const due = (total * 0.55).toFixed(2);
+        const pickup = new Date(booking.pickup_date);
+        const dropoff = new Date(booking.return_date);
+        const rentalDays = Math.ceil((dropoff - pickup) / (1000 * 60 * 60 * 24)) + 1;
+        const base = (parseFloat(booking.daily_rate) || 0) * rentalDays;
+        const paid = (base * 0.45).toFixed(2);
+        const due = (total - parseFloat(paid)).toFixed(2);
 
         const recipients = [booking.customer_email];
         if (process.env.ADMIN_NOTIFICATION_EMAIL) {


### PR DESCRIPTION
## Summary
- adjust partial payment to be based on car price only
- show correct remaining balance after addons
- compute paid/due in confirmation emails using base rental price
- update admin dashboard calculations

## Testing
- `npm install`
- `node tests/mobileSidebar.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68469e92ff8483329ace367e3c0bc027