### PR TITLE
Fix checkout price calculations

### DIFF
--- a/assets/js/dynamic-pricing.js
+++ b/assets/js/dynamic-pricing.js
@@ -257,19 +257,19 @@ async function calculateTotalPrice(carName, startDate, endDate, extras = {}) {
   
   // Only add cost if the extra has a price greater than 0
   if (extras.additionalDriver && pricingData.extras.additionalDriver > 0) {
-    extrasTotal += pricingData.extras.additionalDriver * duration;
+    extrasTotal += pricingData.extras.additionalDriver;
   }
-  
+
   if (extras.fullInsurance && pricingData.extras.fullInsurance > 0) {
-    extrasTotal += pricingData.extras.fullInsurance * duration;
+    extrasTotal += pricingData.extras.fullInsurance;
   }
-  
+
   if (extras.gpsNavigation && pricingData.extras.gpsNavigation > 0) {
-    extrasTotal += pricingData.extras.gpsNavigation * duration;
+    extrasTotal += pricingData.extras.gpsNavigation;
   }
-  
+
   if (extras.childSeat && pricingData.extras.childSeat > 0) {
-    extrasTotal += pricingData.extras.childSeat * duration;
+    extrasTotal += pricingData.extras.childSeat;
   }
   
   // Calculate total price
@@ -569,7 +569,7 @@ function updateExtrasLabels() {
   const childSeatLabel = document.querySelector('label[for="childSeat"]');
   if (childSeatLabel) {
     const price = pricingData.extras.childSeat;
-    childSeatLabel.textContent = `Child Seat (+${formatPrice(price)}/day)`;
+    childSeatLabel.textContent = `Child Seat (+${formatPrice(price)}/rental)`;
   }
 }
 

--- a/booking-details.html
+++ b/booking-details.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Booking Details - Calma Car Rental</title>
-  <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="assets/css/styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
   <style>
     body {

--- a/choose-car.html
+++ b/choose-car.html
@@ -13,8 +13,8 @@
     <link rel="icon" href="favicon.ico" type="image/x-icon">
     
     <!-- Stylesheet -->
-    <link rel="stylesheet" href="styles.css">
-    <link rel="stylesheet" href="css/booking.css">
+    <link rel="stylesheet" href="assets/css/styles.css">
+    <link rel="stylesheet" href="assets/css/booking.css">
     <!-- Add Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <!-- Add Tailwind CSS -->

--- a/payment.html
+++ b/payment.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Payment - Calma Car Rental</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="assets/css/styles.css">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
   <style>
     /* Reset and base styles */
@@ -286,8 +286,9 @@
 
           const basePrice = (bookingData.selectedCar && bookingData.durationDays)
             ? bookingData.selectedCar.price * bookingData.durationDays
-            : bookingData.totalPrice;
-          const partialAmount = Math.round(basePrice * 0.45);
+            : bookingData.totalPrice || 0;
+          const totalPrice = bookingData.totalPrice || basePrice;
+          const partialAmount = parseFloat((totalPrice * 0.45).toFixed(2));
           bookingData.partialAmount = partialAmount;
           localStorage.setItem('currentBooking', JSON.stringify(bookingData));
 
@@ -352,12 +353,11 @@
           }
           document.getElementById('options').textContent = options;
           if (bookingData.totalPrice || (bookingData.selectedCar && bookingData.durationDays)) {
-            if (bookingData.totalPrice || (bookingData.selectedCar && bookingData.durationDays)) {
             const base = (bookingData.selectedCar && bookingData.durationDays)
               ? bookingData.selectedCar.price * bookingData.durationDays
-              : bookingData.totalPrice;
+              : bookingData.totalPrice || 0;
             const total = bookingData.totalPrice || base;
-            const partial = (base * 0.45).toFixed(2);
+            const partial = (total * 0.45).toFixed(2);
             const remaining = (total - parseFloat(partial)).toFixed(2);
             document.getElementById('total-amount').textContent = `€${total.toFixed(2)}`;
             document.getElementById('partial-amount').textContent = `€${partial}`;

--- a/personal-info.html
+++ b/personal-info.html
@@ -1257,7 +1257,7 @@
                         <input type="checkbox" id="childSeat" name="addons" value="child-seat" class="form-checkbox h-5 w-5 text-blue-600">
                         <div>
                             <span class="font-medium">Child Seat</span>
-                            <p id="childSeatPrice" class="text-sm text-gray-600">$7.50 per day</p>
+                            <p id="childSeatPrice" class="text-sm text-gray-600">$7.50 per rental</p>
                         </div>
                     </label>
                 </div>
@@ -1266,7 +1266,7 @@
                         <input type="checkbox" id="boosterSeat" name="addons" value="booster-seat" class="form-checkbox h-5 w-5 text-blue-600">
                         <div>
                             <span class="font-medium">Booster Seat</span>
-                            <p id="boosterSeatPrice" class="text-sm text-gray-600">$5.00 per day</p>
+                            <p id="boosterSeatPrice" class="text-sm text-gray-600">$5.00 per rental</p>
                         </div>
                     </label>
                 </div>
@@ -1412,11 +1412,11 @@
             if (addon.id === 'child-seat') {
               optionPrices.childSeat = addon.price;
               const p = document.getElementById('childSeatPrice');
-              if (p) p.textContent = `€${addon.price.toFixed(2)} per day`;
+              if (p) p.textContent = `€${addon.price.toFixed(2)} per rental`;
             } else if (addon.id === 'booster-seat') {
               optionPrices.boosterSeat = addon.price;
               const p = document.getElementById('boosterSeatPrice');
-              if (p) p.textContent = `€${addon.price.toFixed(2)} per day`;
+              if (p) p.textContent = `€${addon.price.toFixed(2)} per rental`;
             }
           });
         }
@@ -1599,19 +1599,19 @@
         const childSeat = childSeatElem ? childSeatElem.checked : false;
         const boosterSeat = boosterSeatElem ? boosterSeatElem.checked : false;
         // Add additional options costs
-        if (childSeat) totalPrice += (optionPrices.childSeat || 0) * durationDays;
-        if (boosterSeat) totalPrice += (optionPrices.boosterSeat || 0) * durationDays;
+        if (childSeat) totalPrice += (optionPrices.childSeat || 0);
+        if (boosterSeat) totalPrice += (optionPrices.boosterSeat || 0);
         
         // Update additional options summary
         const additionalOptionsSummary = document.getElementById('additional-options-summary');
         additionalOptionsSummary.innerHTML = '';
         
         if (childSeat) {
-          additionalOptionsSummary.innerHTML += `<div class="option-item">Child Seat: €${((optionPrices.childSeat || 0) * durationDays).toFixed(2)}</div>`;
+          additionalOptionsSummary.innerHTML += `<div class="option-item">Child Seat: €${(optionPrices.childSeat || 0).toFixed(2)}</div>`;
         }
-        
+
         if (boosterSeat) {
-          additionalOptionsSummary.innerHTML += `<div class="option-item">Booster Seat: €${((optionPrices.boosterSeat || 0) * durationDays).toFixed(2)}</div>`;
+          additionalOptionsSummary.innerHTML += `<div class="option-item">Booster Seat: €${(optionPrices.boosterSeat || 0).toFixed(2)}</div>`;
         }
         
         if (!childSeat && !boosterSeat) {
@@ -1786,8 +1786,8 @@
             const childSeat = document.getElementById('childSeat').checked;
             const boosterSeat = document.getElementById('boosterSeat').checked;
             // Add additional options costs
-            if (childSeat) totalPrice += (optionPrices.childSeat || 0) * durationDays;
-            if (boosterSeat) totalPrice += (optionPrices.boosterSeat || 0) * durationDays;
+            if (childSeat) totalPrice += (optionPrices.childSeat || 0);
+            if (boosterSeat) totalPrice += (optionPrices.boosterSeat || 0);
             console.log('Fetched totalPrice before booking:', totalPrice);
             if (!totalPrice || totalPrice <= 0) {
               alert('Could not fetch price for this car and dates. Please try again or contact support.');
@@ -1811,7 +1811,7 @@
               dropoff_location: urlParams.get('dropoff-location'),
               car_make: finalCarMake,
               car_model: finalCarModel,
-              daily_rate: Math.round(totalPrice / durationDays),
+              daily_rate: Math.round(finalDailyRate),
               total_price: totalPrice,
               child_seat: childSeat,
               booster_seat: boosterSeat,


### PR DESCRIPTION
## Summary
- treat add-ons as flat fees
- adjust deposit calculation on the payment page
- show per-rental pricing for extras

## Testing
- `npm install`
- `node tests/mobileSidebar.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6846afa0efe48332bd9958c76f38146b