### PR TITLE
Fix booking pricing summary and email

### DIFF
--- a/booking-confirmation.html
+++ b/booking-confirmation.html
@@ -104,6 +104,9 @@
             const bookingReference = urlParams.get('reference');
             const sessionId = urlParams.get('session_id');
 
+            // Clear stored booking data to prevent stale pricing
+            localStorage.removeItem('currentBooking');
+
             if (!bookingReference) {
                 showError('No booking reference found. Please check your confirmation email or contact customer support.');
                 return;
@@ -178,15 +181,8 @@
                 document.getElementById('carInfo').textContent = `${rental.car_make} ${rental.car_model}`;
                 document.getElementById('dailyRate').textContent = formatCurrency(rental.daily_rate);
                 document.getElementById('totalPrice').textContent = formatCurrency(rental.total_price);
-                const stored = JSON.parse(localStorage.getItem('currentBooking') || '{}');
                 const total = parseFloat(rental.total_price) || 0;
-                let partial;
-                if (stored.partialAmount) {
-                    partial = parseFloat(stored.partialAmount);
-                
-                } else {
-                    partial = parseFloat((total * 0.45).toFixed(2));
-                }
+                const partial = parseFloat((total * 0.45).toFixed(2));
                 const remaining = (total - partial).toFixed(2);
                 document.getElementById('partialPaid').textContent = `€${partial.toFixed(2)}`;
                 document.getElementById('remainingBalance').textContent = `€${remaining}`;


### PR DESCRIPTION
## Summary
- clear local booking cache on confirmation page
- show partial payment as 45% of total price
- always send confirmation email in confirm-payment API
- add admin endpoint `/api/admin/cars` to return car data with daily rate calculated correctly
- add more logs for payment confirmation and email sending

## Testing
- `npm install`
- `node tests/mobileSidebar.test.js` (with "Not implemented: window.scrollTo" warnings)


------
https://chatgpt.com/codex/tasks/task_e_6846cc2a4314833282c27317f6dfe0bf