### PR TITLE
Fix pricing retrieval by month

### DIFF
--- a/CHECKTHIS/admin.js
+++ b/CHECKTHIS/admin.js
@@ -1330,6 +1330,7 @@ window.saveMonthlyPricingMonth = async function(carId, monthKey, btn) {
         });
         const data = await res.json();
         if (!data.success) throw new Error(data.error || 'Failed to update pricing');
+        car.monthly_pricing = pricing;
         btn.textContent = 'Saved!';
         setTimeout(() => { btn.textContent = 'Save'; btn.disabled = false; }, 1200);
         alert('Pricing updated successfully!');

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1713,6 +1713,7 @@ window.saveMonthlyPricingMonth = async function(carId, monthKey, btn) {
         });
         const data = await res.json();
         if (!data.success) throw new Error(data.error || 'Failed to update pricing');
+        car.monthly_pricing = pricing;
         btn.textContent = 'Saved!';
         setTimeout(() => { btn.textContent = 'Save'; btn.disabled = false; }, 1200);
         alert('Pricing updated successfully!');

--- a/server.js
+++ b/server.js
@@ -1473,8 +1473,27 @@ app.get('/api/get-price', async (req, res) => {
                 error: 'Car not found'
             });
         }
-        const monthlyPricing = result.rows[0].monthly_pricing;
-        const monthPricing = monthlyPricing[month];
+        let monthlyPricing = result.rows[0].monthly_pricing;
+        // PG can return JSON as a string in some cases
+        if (typeof monthlyPricing === 'string') {
+            try {
+                monthlyPricing = JSON.parse(monthlyPricing);
+            } catch (e) {
+                monthlyPricing = {};
+            }
+        }
+        let monthPricing = monthlyPricing[month];
+        if (!monthPricing) {
+            const months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+            const parts = month.split('-');
+            if (parts.length === 2) {
+                const mIndex = parseInt(parts[1],10) - 1;
+                const nameKey = months[mIndex];
+                if (nameKey) {
+                    monthPricing = monthlyPricing[nameKey];
+                }
+            }
+        }
         if (!monthPricing) {
             return res.status(404).json({
                 success: false,


### PR DESCRIPTION
## Summary
- handle month-name pricing for `/api/get-price` endpoint

## Testing
- `node tests/mobileSidebar.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688b3ddb77048332818c19454df26c96