### PR TITLE
Improve manual blocks export styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ejs": "^3.1.9",
     "esbuild": "^0.25.5",
     "esbuild-register": "^3.6.0",
+    "exceljs": "^4.4.0",
     "express": "^4.18.2",
     "express-session": "^1.18.1",
     "express-validator": "^7.2.1",
@@ -38,7 +39,6 @@
     "resend": "^4.5.2",
     "stripe": "^18.2.1",
     "uuid": "^11.1.0",
-    "xlsx": "^0.18.5",
     "xss": "^1.0.15"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- remove unused `xlsx` dependency and use `exceljs`
- enhance manual blocks export with ExcelJS

## Testing
- `node tests/mobileSidebar.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688b61fd5f7c8332ada656ce31cc1480