### PR TITLE
Add manual block export route

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -2115,9 +2115,7 @@ async function deleteManualBlock(blockId) {
 // Trigger manual block export and download file
 async function exportManualBlocks() {
     try {
-        const res = await fetch('/api/admin/manual-blocks/export', {
-            headers: { 'Authorization': `Bearer ${localStorage.getItem('adminToken')}` }
-        });
+        const res = await fetch('/api/manual-blocks/export');
         if (!res.ok) throw new Error('Failed to export manual blocks');
         const blob = await res.blob();
         const url = window.URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- implement helper to export manual blocks to Excel
- add public `/api/manual-blocks/export` route and reuse it from the admin path
- update admin panel to call new route

## Testing
- `npm install`
- `node tests/mobileSidebar.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688b64abd164833285ae4cbad9def63e