### PR TITLE
Fix CSP for inline event handlers

### DIFF
--- a/server.js
+++ b/server.js
@@ -102,6 +102,7 @@ app.use(
         'cdn.jsdelivr.net',
         'unpkg.com'
       ],
+      scriptSrcAttr: ["'unsafe-inline'"],
       styleSrc: [
         "'self'",
         "'unsafe-inline'",


### PR DESCRIPTION
## Summary
- allow inline event handler attributes

## Testing
- `node tests/mobileSidebar.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688c897af6c88332bd965847e4ed2d82