### PR TITLE
Fix manual block actions requiring session cookie

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1929,6 +1929,7 @@ async function loadCarAvailability() {
                             'Content-Type': 'application/json',
                             'Authorization': `Bearer ${localStorage.getItem('adminToken')}`
                         },
+                        credentials: 'include',
                         body: JSON.stringify(payload)
                     });
                     
@@ -2104,7 +2105,8 @@ async function deleteManualBlock(blockId) {
             method: 'DELETE',
             headers: {
                 'Authorization': `Bearer ${localStorage.getItem('adminToken')}`
-            }
+            },
+            credentials: 'include'
         });
         const data = await res.json();
         if (data.success) {


### PR DESCRIPTION
## Summary
- ensure add/delete manual block requests send session credentials

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688c952e247083328d2bf87174282ab1