### PR TITLE
Fix fleet book now redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -796,7 +796,7 @@
                                 <span class="car-feature">Available</span>
                                 <span class="price-note">· Free cancellation</span>
                             </div>
-                            <a href="/car-selection.html" class="btn btn-primary">Book Now</a>
+                            <a href="/" class="btn btn-primary">Book Now</a>
                         </div>
                     </div>
                     
@@ -812,7 +812,7 @@
                                 <span class="car-feature">Available</span>
                                 <span class="price-note">· Free cancellation</span>
                             </div>
-                            <a href="/car-selection.html" class="btn btn-primary">Book Now</a>
+                            <a href="/" class="btn btn-primary">Book Now</a>
                         </div>
                     </div>
                     
@@ -828,7 +828,7 @@
                                 <span class="car-feature">Available</span>
                                 <span class="price-note">· Free cancellation</span>
                             </div>
-                            <a href="/car-selection.html" class="btn btn-primary">Book Now</a>
+                            <a href="/" class="btn btn-primary">Book Now</a>
                         </div>
                     </div>
                     
@@ -844,7 +844,7 @@
                                 <span class="car-feature">Available</span>
                                 <span class="price-note">· Free cancellation</span>
                             </div>
-                            <a href="/car-selection.html" class="btn btn-primary">Book Now</a>
+                            <a href="/" class="btn btn-primary">Book Now</a>
                         </div>
                     </div>
                     
@@ -860,7 +860,7 @@
                                 <span class="car-feature">Available</span>
                                 <span class="price-note">· Free cancellation</span>
                             </div>
-                            <a href="/car-selection.html" class="btn btn-primary">Book Now</a>
+                            <a href="/" class="btn btn-primary">Book Now</a>
                         </div>
                     </div>
                     
@@ -876,7 +876,7 @@
                                 <span class="car-feature">Available</span>
                                 <span class="price-note">· Free cancellation</span>
                             </div>
-                            <a href="/car-selection.html" class="btn btn-primary">Book Now</a>
+                            <a href="/" class="btn btn-primary">Book Now</a>
                         </div>
                     </div>
                     <!-- Car 7 -->
@@ -891,7 +891,7 @@
                                 <span class="car-feature">Available</span>
                                 <span class="price-note">· Free cancellation</span>
                             </div>
-                            <a href="/car-selection.html" class="btn btn-primary">Book Now</a>
+                            <a href="/" class="btn btn-primary">Book Now</a>
                         </div>
                     </div>
 
@@ -907,7 +907,7 @@
                                 <span class="car-feature">Available</span>
                                 <span class="price-note">· Free cancellation</span>
                             </div>
-                            <a href="/car-selection.html" class="btn btn-primary">Book Now</a>
+                            <a href="/" class="btn btn-primary">Book Now</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- adjust fleet `Book Now` links to redirect to the site root

## Testing
- `node tests/mobileSidebar.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688c98753cf48332988617939fdf9570