### PR TITLE
Fix modal close buttons and positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,11 +274,13 @@
             height: 100%;
             background: rgba(0, 0, 0, 0.7);
             z-index: 1000;
+            justify-content: center;
+            align-items: center;
         }
 
         #privacy-modal .modal-content {
             background: white;
-            margin: 10% auto;
+            margin: 0;
             padding: 2rem;
             width: 80%;
             max-width: 700px;
@@ -287,6 +289,7 @@
             overflow-y: auto;
             box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
             animation: modalFadeIn 0.3s ease;
+            position: relative;
         }
 
         @keyframes modalFadeIn {
@@ -295,7 +298,9 @@
         }
 
         #privacy-modal .close-modal {
-            float: right;
+            position: absolute;
+            top: 10px;
+            right: 10px;
             font-size: 28px;
             cursor: pointer;
             color: #999;
@@ -340,7 +345,7 @@
         @media (max-width: 768px) {
             #privacy-modal .modal-content {
                 padding: 1.5rem;
-                margin: 15% auto;
+                margin: 0;
                 width: 90%;
             }
         }
@@ -355,11 +360,13 @@
             height: 100%;
             background: rgba(0, 0, 0, 0.7);
             z-index: 1000;
+            justify-content: center;
+            align-items: center;
         }
 
         #terms-modal .modal-content {
             background: white;
-            margin: 10% auto;
+            margin: 0;
             padding: 2rem;
             width: 80%;
             max-width: 700px;
@@ -368,10 +375,13 @@
             overflow-y: auto;
             box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
             animation: modalFadeIn 0.3s ease;
+            position: relative;
         }
 
         #terms-modal .close-modal {
-            float: right;
+            position: absolute;
+            top: 10px;
+            right: 10px;
             font-size: 28px;
             cursor: pointer;
             color: #999;
@@ -417,7 +427,7 @@
         @media (max-width: 768px) {
             #terms-modal .modal-content {
                 padding: 1.5rem;
-                margin: 15% auto;
+                margin: 0;
                 width: 90%;
             }
         }
@@ -1290,7 +1300,7 @@
     <!-- Privacy Policy Modal -->
     <div id="privacy-modal" class="modal">
         <div class="modal-content">
-            <span class="close-modal">&times;</span>
+            <span class="close-modal" role="button" aria-label="Close">&times;</span>
             <h2>Privacy Policy</h2>
             <div class="privacy-content">
                 <h3>1. Introduction</h3>
@@ -1360,7 +1370,7 @@
     <!-- Terms & Conditions Modal -->
     <div id="terms-modal" class="modal">
         <div class="modal-content">
-            <span class="close-modal">&times;</span>
+            <span class="close-modal" role="button" aria-label="Close">&times;</span>
             <h2>Terms & Conditions</h2>
             <div class="terms-content">
                 <h3>1. Introduction</h3>
@@ -1541,7 +1551,7 @@
             // Helper to show a modal
             function openModal(modal) {
                 if (modal) {
-                    modal.style.display = 'block';
+                    modal.style.display = 'flex';
                 }
             }
 
@@ -1557,6 +1567,12 @@
                     e.preventDefault();
                     openModal(privacyModal);
                 });
+                const closeBtn = privacyModal.querySelector('.close-modal');
+                if (closeBtn) {
+                    closeBtn.addEventListener('click', function () {
+                        closeModal(privacyModal);
+                    });
+                }
             }
 
             if (termsLink) {
@@ -1564,15 +1580,13 @@
                     e.preventDefault();
                     openModal(termsModal);
                 });
+                const closeBtn = termsModal.querySelector('.close-modal');
+                if (closeBtn) {
+                    closeBtn.addEventListener('click', function () {
+                        closeModal(termsModal);
+                    });
+                }
             }
-
-            // Close modal when X button is clicked
-            document.querySelectorAll('.close-modal').forEach(function (btn) {
-                btn.addEventListener('click', function () {
-                    const modal = btn.closest('.modal');
-                    closeModal(modal);
-                });
-            });
 
             // Close modal when clicking outside the content
             window.addEventListener('click', function (event) {


### PR DESCRIPTION
## Summary
- improve modal centering and ensure close buttons stay visible
- add role attributes for accessibility
- adjust scripts so close icons reliably dismiss each modal

## Testing
- `node tests/mobileSidebar.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688ca0f650108332b4a0544d64e096b7