### PR TITLE
Add new Citroën C3 777 model

### DIFF
--- a/assets/js/pricing.json
+++ b/assets/js/pricing.json
@@ -44,6 +44,17 @@
       "October": 50,
       "extraDay": 35
     },
+    "citroen-c3-777": {
+      "category": "C",
+      "April": 55,
+      "May": 65,
+      "June": 70,
+      "July": 80,
+      "August": 90,
+      "September": 70,
+      "October": 50,
+      "extraDay": 35
+    },
     "Volkswagen Golf": {
       "category": "D",
       "April": 65,

--- a/cars.json
+++ b/cars.json
@@ -40,6 +40,22 @@
     "features": ["Manual", "5 Seats", "Air Conditioning", "Bluetooth"]
   },
   {
+    "id": "citroen-c3-777",
+    "name": "Citroën C3",
+    "description": "Stylish compact car with excellent comfort.",
+    "pricePerDay": 40,
+    "image": "/images/CitroenC3_A.jpg",
+    "features": [
+      "Air Condition",
+      "ABS",
+      "Airbag",
+      "Bluetooth",
+      "Parking Sensors (\u0391\u03b9\u03c3\u03b8\u03b7\u03c4\u03ae\u03c1\u03b5\u03c2)",
+      "Rear Camera (\u039a\u03ac\u03bc\u03b5\u03c1\u03b1)",
+      "Heated Seats (\u0398\u03b5\u03c1\u03bc\u03b1\u03b9\u03bd\u03cc\u03bc\u03b5\u03bd\u03b1 \u03ba\u03b1\u03b8\u03af\u03c3\u03bc\u03b1\u03c4\u03b1)"
+    ]
+  },
+  {
     "id": "swift",
     "name": "Suzuki Swift",
     "description": "Sporty and nimble, ideal for exploring Crete.",

--- a/index.html
+++ b/index.html
@@ -877,6 +877,22 @@
                     <!-- Car 6 -->
                     <div class="car-card" style="opacity: 1; transform: translateY(0);">
                         <div class="car-image">
+                            <img src="images/CitroenC3_A.jpg" alt="Citroën C3 rental car" title="Photo of Citroën C3" loading="lazy" width="300" height="200">
+                        </div>
+                        <div class="car-details">
+                            <h3>Citroën C3</h3>
+                            <p>Stylish compact car with excellent comfort.</p>
+                            <div class="car-pricing">
+                                <span class="car-feature">Available</span>
+                                <span class="price-note">· Free cancellation</span>
+                            </div>
+                            <a href="/" class="btn btn-primary">Book Now</a>
+                        </div>
+                    </div>
+
+                    <!-- Car 7 -->
+                    <div class="car-card" style="opacity: 1; transform: translateY(0);">
+                        <div class="car-image">
                             <img src="images/CalmaSuzuki.jpg" alt="Suzuki Celerio" title="Photo of Suzuki Celerio" loading="lazy" width="300" height="200">
                         </div>
                         <div class="car-details">
@@ -889,7 +905,8 @@
                             <a href="/" class="btn btn-primary">Book Now</a>
                         </div>
                     </div>
-                    <!-- Car 7 -->
+
+                    <!-- Car 8 -->
                     <div class="car-card" style="opacity: 1; transform: translateY(0);">
                         <div class="car-image">
                             <img src="images/CalmaFiatPanda.jpg" alt="Fiat Panda" title="Photo of Fiat Panda" loading="lazy" width="300" height="200">
@@ -905,7 +922,7 @@
                         </div>
                     </div>
 
-                    <!-- Car 8 -->
+                    <!-- Car 9 -->
                     <div class="car-card" style="opacity: 1; transform: translateY(0);">
                         <div class="car-image">
                             <img src="images/CalmaAudiA3.jpg" alt="Audi A3" title="Photo of Audi A3" loading="lazy" width="300" height="200">

--- a/utils/seed-citroen-c3-777.js
+++ b/utils/seed-citroen-c3-777.js
@@ -1,0 +1,66 @@
+require('dotenv').config();
+const { pool } = require('../database');
+
+(async () => {
+  const baseId = 'citroen-c3-777';
+  let carId = baseId;
+  try {
+    // Check for existing slug
+    const check = await pool.query('SELECT car_id FROM cars WHERE car_id = $1', [carId]);
+    if (check.rowCount > 0) {
+      carId = `${baseId}-b`;
+      const checkB = await pool.query('SELECT car_id FROM cars WHERE car_id = $1', [carId]);
+      if (checkB.rowCount > 0) {
+        console.log(`Car with id ${baseId} and fallback already exists. Skipping seeding.`);
+        await pool.end();
+        return;
+      }
+    }
+
+    const features = [
+      'Air Condition',
+      'ABS',
+      'Airbag',
+      'Bluetooth',
+      'Parking Sensors (\u0391\u03b9\u03c3\u03b8\u03b7\u03c4\u03ae\u03c1\u03b5\u03c2)',
+      'Rear Camera (\u039a\u03ac\u03bc\u03b5\u03c1\u03b1)',
+      'Heated Seats (\u0398\u03b5\u03c1\u03bc\u03b1\u03b9\u03bd\u03cc\u03bc\u03b5\u03bd\u03b1 \u03ba\u03b1\u03b8\u03af\u03c3\u03bc\u03b1\u03c4\u03b1)'
+    ];
+
+    const specs = {
+      engine: '1.2 Gasoline',
+      gearbox: 'Manual',
+      fuel: 'Petrol',
+      passengers: 5,
+      doors: 5,
+      luggage: '2 small',
+      airCondition: true,
+      abs: true,
+      airbag: true,
+      entertainment: 'Bluetooth'
+    };
+
+    await pool.query(
+      `INSERT INTO cars (car_id, name, description, image, category, features, specs, monthly_pricing, available)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+       ON CONFLICT (car_id) DO NOTHING`,
+      [
+        carId,
+        'Citro\u00ebn C3',
+        'Stylish compact car with excellent comfort.',
+        '/images/CitroenC3_A.jpg',
+        'Economy',
+        JSON.stringify(features),
+        JSON.stringify(specs),
+        '{}',
+        true
+      ]
+    );
+
+    console.log(`\u2705 Seeded car with id ${carId}`);
+  } catch (err) {
+    console.error('\u274c Error seeding car:', err.message);
+  } finally {
+    await pool.end();
+  }
+})();


### PR DESCRIPTION
## Summary
- add `citroen-c3-777` car entry with full specs and features
- surface new Citroën C3 on fleet showcase
- extend pricing data and provide seeding script for new car

## Testing
- `npm test` *(fails: Missing script: "test")*
- `curl http://localhost:3000/api/cars` *(fails: Database not connected)*

------
https://chatgpt.com/codex/tasks/task_e_68a440f20ec88332abfb4e583a7346fa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded the fleet display from 5 to 9 cars, adding an additional Citroën C3 variant, a Fiat Panda, and an Audi A3 with images, descriptions, availability, and “Book Now” actions.
  - Introduced pricing for the new Citroën C3 variant, aligned with existing seasonal rates for easy comparison and booking.
  - Enhanced car details with richer feature information to help users choose the right vehicle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->