### PR TITLE
Add Citroen C3_B variant with custom selection label

### DIFF
--- a/assets/js/fix-cars.js
+++ b/assets/js/fix-cars.js
@@ -520,15 +520,16 @@ document.addEventListener('DOMContentLoaded', function() {
           imageUrl = 'images/CalmaLogo.jpg';
         }
       }
+      const displayName = car.id === 'citroen-c3-b' ? 'Citroen C3_2' : car.name;
       html += `
         <div class="car-card" data-car-id="${car.id}">
           <div class="car-image">
-            <img src="${imageUrl}" alt="${car.name}" title="Photo of ${car.name}" onerror="this.src='images/CalmaLogo.jpg'">
+            <img src="${imageUrl}" alt="${displayName}" title="Photo of ${displayName}" onerror="this.src='images/CalmaLogo.jpg'">
             <div class="car-category">${car.category}</div>
           </div>
           <div class="car-details">
             <div>
-              <h3>${car.name}</h3>
+              <h3>${displayName}</h3>
               <div class="car-group">Group ${car.group || ''}</div>
               <p>${car.description || ''}</p>
             </div>
@@ -538,9 +539,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 <div class="car-price">Loading...</div>
                 <div class="total-price" style="display:none;"></div>
               </div>
-              <button class="select-car-btn${!isAvailable ? ' unavailable-btn' : ''}" 
-                      data-car-id="${car.id}" 
-                      data-car-name="${car.name}" 
+              <button class="select-car-btn${!isAvailable ? ' unavailable-btn' : ''}"
+                      data-car-id="${car.id}"
+                      data-car-name="${displayName}"
                       data-car-price="0"
                       ${!isAvailable ? 'disabled' : ''}>
                 ${isAvailable ? 'Select This Car' : 'Unavailable'}

--- a/assets/js/pricing.json
+++ b/assets/js/pricing.json
@@ -55,6 +55,28 @@
       "October": 50,
       "extraDay": 35
     },
+    "citroen-c3-b": {
+      "category": "C",
+      "April": 55,
+      "May": 65,
+      "June": 70,
+      "July": 80,
+      "August": 90,
+      "September": 70,
+      "October": 50,
+      "extraDay": 35
+    },
+    "Citroen C3_2": {
+      "category": "C",
+      "April": 55,
+      "May": 65,
+      "June": 70,
+      "July": 80,
+      "August": 90,
+      "September": 70,
+      "October": 50,
+      "extraDay": 35
+    },
     "Volkswagen Golf": {
       "category": "D",
       "April": 65,
@@ -83,4 +105,4 @@
     "7": 0.7
   },
   "prepaymentPercentage": 45
-} 
+}

--- a/cars.json
+++ b/cars.json
@@ -5,7 +5,12 @@
     "description": "Compact and fuel-efficient, perfect for city driving.",
     "pricePerDay": 35,
     "image": "https://calmarental.com/images/CalmaAygo.jpg",
-    "features": ["Automatic", "4 Seats", "Air Conditioning", "Fuel Efficient"]
+    "features": [
+      "Automatic",
+      "4 Seats",
+      "Air Conditioning",
+      "Fuel Efficient"
+    ]
   },
   {
     "id": "tiguan",
@@ -13,7 +18,12 @@
     "description": "Spacious SUV with advanced features for comfort.",
     "pricePerDay": 75,
     "image": "https://calmarental.com/images/CalmaTiguan.jpg",
-    "features": ["Automatic", "5 Seats", "SUV", "Bluetooth"]
+    "features": [
+      "Automatic",
+      "5 Seats",
+      "SUV",
+      "Bluetooth"
+    ]
   },
   {
     "id": "golf",
@@ -21,7 +31,12 @@
     "description": "Versatile hatchback with excellent handling.",
     "pricePerDay": 55,
     "image": "https://calmarental.com/images/CalmaGolf.jpg",
-    "features": ["Automatic", "5 Seats", "Air Conditioning", "Cruise Control"]
+    "features": [
+      "Automatic",
+      "5 Seats",
+      "Air Conditioning",
+      "Cruise Control"
+    ]
   },
   {
     "id": "i10",
@@ -29,7 +44,12 @@
     "description": "Economical and easy to drive mini car.",
     "pricePerDay": 32,
     "image": "https://calmarental.com/images/Calmai10.jpg",
-    "features": ["Manual", "4 Seats", "Air Conditioning", "Compact"]
+    "features": [
+      "Manual",
+      "4 Seats",
+      "Air Conditioning",
+      "Compact"
+    ]
   },
   {
     "id": "c3",
@@ -37,7 +57,12 @@
     "description": "Stylish compact car with excellent comfort.",
     "pricePerDay": 40,
     "image": "https://calmarental.com/images/CalmaCitroen.jpg",
-    "features": ["Manual", "5 Seats", "Air Conditioning", "Bluetooth"]
+    "features": [
+      "Manual",
+      "5 Seats",
+      "Air Conditioning",
+      "Bluetooth"
+    ]
   },
   {
     "id": "citroen-c3-777",
@@ -50,9 +75,25 @@
       "ABS",
       "Airbag",
       "Bluetooth",
-      "Parking Sensors (\u0391\u03b9\u03c3\u03b8\u03b7\u03c4\u03ae\u03c1\u03b5\u03c2)",
-      "Rear Camera (\u039a\u03ac\u03bc\u03b5\u03c1\u03b1)",
-      "Heated Seats (\u0398\u03b5\u03c1\u03bc\u03b1\u03b9\u03bd\u03cc\u03bc\u03b5\u03bd\u03b1 \u03ba\u03b1\u03b8\u03af\u03c3\u03bc\u03b1\u03c4\u03b1)"
+      "Parking Sensors (Αισθητήρες)",
+      "Rear Camera (Κάμερα)",
+      "Heated Seats (Θερμαινόμενα καθίσματα)"
+    ]
+  },
+  {
+    "id": "citroen-c3-b",
+    "name": "Citroen C3_B",
+    "description": "Stylish compact car with excellent comfort.",
+    "pricePerDay": 40,
+    "image": "/images/CitroenC3_A.jpg",
+    "features": [
+      "Air Condition",
+      "ABS",
+      "Airbag",
+      "Bluetooth",
+      "Parking Sensors (Αισθητήρες)",
+      "Rear Camera (Κάμερα)",
+      "Heated Seats (Θερμαινόμενα καθίσματα)"
     ]
   },
   {
@@ -61,6 +102,11 @@
     "description": "Sporty and nimble, ideal for exploring Crete.",
     "pricePerDay": 38,
     "image": "https://calmarental.com/images/CalmaSuzuki.jpg",
-    "features": ["Manual", "5 Seats", "Air Conditioning", "Sporty"]
+    "features": [
+      "Manual",
+      "5 Seats",
+      "Air Conditioning",
+      "Sporty"
+    ]
   }
-] 
+]


### PR DESCRIPTION
## Summary
- add Citroen C3_B to fleet data and pricing tables
- show Citroen C3_B as "Citroen C3_2" in customer car selection

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a44c41a3188332b8af83d49b5c961c