### PR TITLE
Remove duplicate Citroen C3 entries

### DIFF
--- a/cars.json
+++ b/cars.json
@@ -65,38 +65,6 @@
     ]
   },
   {
-    "id": "citroen-c3-777",
-    "name": "Citroën C3",
-    "description": "Stylish compact car with excellent comfort.",
-    "pricePerDay": 40,
-    "image": "/images/CitroenC3_A.jpg",
-    "features": [
-      "Air Condition",
-      "ABS",
-      "Airbag",
-      "Bluetooth",
-      "Parking Sensors (Αισθητήρες)",
-      "Rear Camera (Κάμερα)",
-      "Heated Seats (Θερμαινόμενα καθίσματα)"
-    ]
-  },
-  {
-    "id": "citroen-c3-b",
-    "name": "Citroen C3_B",
-    "description": "Stylish compact car with excellent comfort.",
-    "pricePerDay": 40,
-    "image": "/images/CitroenC3_A.jpg",
-    "features": [
-      "Air Condition",
-      "ABS",
-      "Airbag",
-      "Bluetooth",
-      "Parking Sensors (Αισθητήρες)",
-      "Rear Camera (Κάμερα)",
-      "Heated Seats (Θερμαινόμενα καθίσματα)"
-    ]
-  },
-  {
     "id": "swift",
     "name": "Suzuki Swift",
     "description": "Sporty and nimble, ideal for exploring Crete.",


### PR DESCRIPTION
## Summary
- Remove redundant Citroën C3 records from `cars.json` to ensure unique IDs.

## Testing
- `node utils/sync-all-cars-to-db.js` *(fails: DATABASE_URL environment variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a4692b916c83329e2a77c868f0e539