### PR TITLE
Require session secret and document rotation

### DIFF
--- a/docs/README-RAILWAY-SETUP.md
+++ b/docs/README-RAILWAY-SETUP.md
@@ -36,6 +36,8 @@ postgresql://postgres:password@containers-us-west-123.railway.app:7890/railway
    - `DATABASE_URL` = [your PostgreSQL connection string]
    - `NODE_ENV` = production
    - `PORT` = 3000
+   - `SESSION_SECRET` = output of `npm run generate-session-secret`
+   - `SESSION_SECRET_PREVIOUS` = previous value when rotating (optional)
 
 4. Deploy your application
 
@@ -47,6 +49,7 @@ postgresql://postgres:password@containers-us-west-123.railway.app:7890/railway
    DATABASE_URL=postgresql://postgres:password@containers-us-west-123.railway.app:7890/railway
    NODE_ENV=production
    PORT=3000
+   SESSION_SECRET=yourRandomStringHere
    ```
 3. Deploy your code to your hosting provider
 
@@ -86,4 +89,6 @@ If you encounter issues, look at the browser's developer console and your Railwa
 ## Security Notes
 
 - Your database contains customer information - make sure admin credentials are secure
-- The provided admin dashboard uses a simple username/password system - consider enhancing security for production 
+- The provided admin dashboard uses a simple username/password system - consider enhancing security for production
+- Generate a strong session secret using `npm run generate-session-secret` and set it as `SESSION_SECRET`
+- Rotate the secret periodically by moving the old value to `SESSION_SECRET_PREVIOUS` and restarting the service

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@ The website is deployed on Railway.com. To deploy:
 1. Push changes to the GitHub repository
 2. Railway automatically detects changes and deploys the updated version
 3. Use the build command `npm run build` to update minified files before pushing
+4. Generate a strong session secret with `npm run generate-session-secret` and set it as the `SESSION_SECRET` environment variable
+5. Rotate the secret regularly; keep the old value in `SESSION_SECRET_PREVIOUS` until existing sessions expire
 
 ## Recent Optimizations
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "build": "echo \"No build step required\""
+    "build": "echo \"No build step required\"",
+    "generate-session-secret": "node utils/generate-session-secret.js"
   },
   "keywords": [
     "car rental",

--- a/server.js
+++ b/server.js
@@ -35,6 +35,17 @@ if (!process.env.STRIPE_SECRET_KEY) {
   throw new Error('Missing STRIPE_SECRET_KEY environment variable');
 }
 
+// Ensure the session secret is provided
+if (!process.env.SESSION_SECRET) {
+  throw new Error('Missing SESSION_SECRET environment variable');
+}
+
+// Support rotation by accepting previous secret
+const sessionSecrets = [process.env.SESSION_SECRET];
+if (process.env.SESSION_SECRET_PREVIOUS) {
+  sessionSecrets.push(process.env.SESSION_SECRET_PREVIOUS);
+}
+
 // Initialize Stripe with error handling
 let stripe;
 try {
@@ -107,7 +118,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
 app.use(session({
-  secret: process.env.SESSION_SECRET || "supersecret",
+  secret: sessionSecrets,
   resave: false,
   saveUninitialized: false,
   cookie: {

--- a/utils/generate-session-secret.js
+++ b/utils/generate-session-secret.js
@@ -1,0 +1,7 @@
+const crypto = require('crypto');
+
+const secret = crypto.randomBytes(64).toString('hex');
+
+console.log(`New SESSION_SECRET: ${secret}`);
+console.log('Set this value as the SESSION_SECRET environment variable.');
+console.log('For rotation, move the previous secret to SESSION_SECRET_PREVIOUS and restart the server.');


### PR DESCRIPTION
## Summary
- fail fast when SESSION_SECRET is missing and allow rotation with SESSION_SECRET_PREVIOUS
- add utility script to generate strong session secrets
- document secret generation and rotation in deployment guides

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run generate-session-secret`

------
https://chatgpt.com/codex/tasks/task_e_68a4d2052db08332ad111c651d70b689