### PR TITLE
Fix booking confirmation loading after Stripe redirect

### DIFF
--- a/booking-confirmation.html
+++ b/booking-confirmation.html
@@ -98,7 +98,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     
     <script type="module">
-        import { calculateInclusiveDisplayDays, formatLocationName } from 'assets/js/utils/date.js';
+        import { calculateInclusiveDisplayDays, formatLocationName } from './assets/js/utils/date.js';
 
         document.addEventListener('DOMContentLoaded', function() {
             // Elements


### PR DESCRIPTION
## Summary
- fix module import path on booking-confirmation page so booking data loads after Stripe redirect

## Testing
- `node tests/dateUtils.test.js`
- `node tests/mobileSidebar.test.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4e34fb25c83328f631a06d6d77e92