### PR TITLE
Add placeholders to personal info form fields

### DIFF
--- a/personal-info.html
+++ b/personal-info.html
@@ -1195,41 +1195,41 @@
         <div class="form-grid">
           <div class="form-group">
             <label class="required">First Name</label>
-            <input type="text" id="firstName" name="firstName" required>
+            <input type="text" id="firstName" name="firstName" placeholder="Enter First Name" required>
             <div id="firstName-error" class="validation-message"></div>
           </div>
-          
+
           <div class="form-group">
             <label class="required">Last Name</label>
-            <input type="text" id="lastName" name="lastName" required>
+            <input type="text" id="lastName" name="lastName" placeholder="Enter Last Name" required>
             <div id="lastName-error" class="validation-message"></div>
           </div>
-          
+
           <div class="form-group">
             <label class="required">Email Address</label>
-            <input type="email" id="email" name="email" required>
+            <input type="email" id="email" name="email" placeholder="Enter Email Address" required>
             <div id="email-error" class="validation-message"></div>
           </div>
-          
+
           <div class="form-group">
             <label class="required">Phone Number</label>
             <div style="display: flex; gap: 0.5rem; align-items: center;">
               <input type="text" id="phoneCountryCode" name="phoneCountryCode" value="+" maxlength="5" required style="width: 60px; text-align: center;" placeholder="+30">
-              <input type="tel" id="phone" name="phone" required placeholder="Phone Number" style="flex: 1;">
+              <input type="tel" id="phone" name="phone" placeholder="Enter Phone Number" required style="flex: 1;">
             </div>
             <div id="phone-error" class="validation-message"></div>
           </div>
-          
+
           <div class="form-group">
             <label class="required">Age</label>
-            <input type="number" id="age" name="age" min="25" max="99" required>
+            <input type="number" id="age" name="age" min="25" max="99" placeholder="Enter Age" required>
             <div id="age-error" class="validation-message"></div>
             <div class="hint">You must be at least 25 years old to rent a car.</div>
           </div>
-          
+
           <div class="form-group">
             <label class="required">Driver's License Number</label>
-            <input type="text" id="driverLicense" name="driverLicense">
+            <input type="text" id="driverLicense" name="driverLicense" placeholder="Enter Driver's License Number">
             <div id="driverLicense-error" class="validation-message"></div>
           </div>
           


### PR DESCRIPTION
## Summary
- Add placeholders for first name, last name, email, phone, age, and driver's license fields on the personal information page
- Retain existing placeholders for license expiration date and country selector

## Testing
- ⚠️ `npm test` (script missing)
- ✅ `node tests/dateUtils.test.js`
- ⚠️ `node tests/mobileSidebar.test.js` (window.scrollTo not implemented, but navigation works)


------
https://chatgpt.com/codex/tasks/task_e_68a56a0e629c8332a1175302c3a57755