### PR TITLE
Fix mobile centering for Our Fleet slider

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -429,7 +429,7 @@ header {
     font-size: 1.1rem;
 }
 
-.cars-grid {
+#cars .cars-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
     gap: 30px;
@@ -1145,7 +1145,7 @@ footer {
     }
     
     /* Make car cards stack nicely */
-    .cars-grid {
+    #cars .cars-grid {
         grid-template-columns: 1fr !important;
         gap: 20px !important;
     }
@@ -2379,17 +2379,24 @@ select#pickup-location, select#dropoff-location {
 
 /* Our Fleet slider overrides */
 .our-fleet-slider {
-    position: relative;
+    overflow: hidden;
 }
 
 .our-fleet-slider .cars-grid {
-    display: flex;
+    display: flex !important;
     gap: 0;
+    align-items: stretch;
 }
 
 .our-fleet-slider .swiper-slide {
     display: flex;
     height: auto;
+    flex: 0 0 auto;
+}
+
+.our-fleet-slider .car-card {
+    width: 100%;
+    margin: 0 auto;
 }
 
 .our-fleet-slider .swiper-button-prev,
@@ -2400,6 +2407,14 @@ select#pickup-location, select#dropoff-location {
 }
 
 @media (max-width: 767px) {
+    .our-fleet-slider .swiper {
+        padding: 0 12px;
+    }
+
+    .our-fleet-slider .swiper-slide {
+        width: calc(100% - 24px);
+    }
+
     .our-fleet-slider .swiper-button-prev,
     .our-fleet-slider .swiper-button-next {
         display: none;

--- a/index.html
+++ b/index.html
@@ -1517,9 +1517,10 @@
             const sliderEl = document.querySelector('.our-fleet-slider');
             if (sliderEl) {
                 new Swiper(sliderEl, {
-                    slidesPerView: 4,
-                    spaceBetween: 24,
                     loop: true,
+                    roundLengths: true,
+                    slidesOffsetBefore: 0,
+                    slidesOffsetAfter: 0,
                     speed: 600,
                     autoplay: {
                         delay: 3000,
@@ -1538,15 +1539,17 @@
                         0: {
                             slidesPerView: 1,
                             centeredSlides: true,
-                            spaceBetween: 0
+                            spaceBetween: 16
                         },
                         768: {
                             slidesPerView: 2,
-                            centeredSlides: false
+                            centeredSlides: false,
+                            spaceBetween: 24
                         },
                         1200: {
                             slidesPerView: 4,
-                            centeredSlides: false
+                            centeredSlides: false,
+                            spaceBetween: 24
                         }
                     },
                     watchOverflow: true,


### PR DESCRIPTION
## Summary
- scope global `.cars-grid` styles to `#cars` and add Swiper-specific flex overrides
- center a single slide on small screens and hide arrows
- update Swiper initialization to use centeredSlides and consistent spacing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a575a9270883328ca3740901b966e3