### PR TITLE
fix: ensure last car visible in swiper

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2414,6 +2414,7 @@ select#pickup-location, select#dropoff-location {
 .our-fleet-slider .swiper {
     padding-left: 12px;
     padding-right: 12px;
+    box-sizing: border-box;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- ensure desktop swiper container uses border-box sizing so final slide renders fully

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a583016c448332840bf91f8d2833d9