### PR TITLE
Replace fleet slider with centered Swiper

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2377,63 +2377,32 @@ select#pickup-location, select#dropoff-location {
     }
 }
 
-/* iOS drift fix */
-.our-fleet-slider {
-    overflow: hidden;
-}
-
-.our-fleet-slider .cars-grid {
-    display: flex !important;
-    gap: 0;
-    align-items: stretch;
-}
-
-/* Ensure slides are measured without surprise margins */
-.our-fleet-slider .swiper-slide {
-    display: flex;
-    height: auto;
-    flex: 0 0 auto;
-    justify-content: center;
-    margin: 0;           /* already zero, keep explicit */
-    box-sizing: border-box;
-}
-
-.our-fleet-slider .car-card {
+/* Our Fleet Swiper */
+.our-fleet-swiper {
     width: 100%;
-    margin: 0 auto;
 }
-
-.our-fleet-slider .swiper-button-prev,
-.our-fleet-slider .swiper-button-next {
+.our-fleet-swiper .cars-grid {
+    display: flex !important;
+}
+.our-fleet-swiper .swiper-slide {
+    display: flex;
+    justify-content: center;
+}
+/* Ensure cards don’t stretch oddly */
+.our-fleet-swiper .swiper-slide > * {
+    max-width: 100%;
+}
+/* Improve iOS smoothness */
+.our-fleet-swiper,
+.our-fleet-swiper .swiper-wrapper,
+.our-fleet-swiper .swiper-slide {
+    will-change: transform;
+}
+.our-fleet-swiper .swiper-button-prev,
+.our-fleet-swiper .swiper-button-next {
     color: var(--primary-color);
-    top: 50%;
-    transform: translateY(-50%);
 }
-
-/* Provide the side breathing room via CSS so widths remain integral */
-.our-fleet-slider .swiper {
-    padding-left: 12px;
-    padding-right: 12px;
-    box-sizing: border-box;
-}
-
-@media (max-width: 768px) {
-    .our-fleet-slider .swiper {
-        padding-left: 15px;
-        padding-right: 15px;
-    }
-
-    .our-fleet-slider .swiper-slide {
-        width: 100% !important;
-    }
-
-    .our-fleet-slider .swiper-button-prev,
-    .our-fleet-slider .swiper-button-next {
-        display: none;
-    }
-}
-
-.our-fleet-slider .swiper-pagination {
+.our-fleet-swiper .swiper-pagination {
     position: static;
     margin-top: 20px;
 }

--- a/index.html
+++ b/index.html
@@ -795,157 +795,176 @@
                     <p>Choose from our selection of well-maintained vehicles to suit your needs</p>
                 </div>
 
-                <div class="our-fleet-slider">
-                    <div class="swiper">
-                        <div class="cars-grid swiper-wrapper">
+                <div class="swiper our-fleet-swiper">
+                    <div class="swiper-wrapper cars-grid">
                         <!-- Car 1 -->
-                    <div class="car-card swiper-slide" style="opacity: 1">
-                        <div class="car-image">
-                            <img src="images/CalmaAygo.jpg" alt="Toyota Aygo" title="Photo of Toyota Aygo" loading="lazy" width="300" height="200">
-                        </div>
-                        <div class="car-details">
-                            <h3>Toyota Aygo</h3>
-                            <p>Compact and fuel-efficient, perfect for city driving.</p>
-                            <div class="car-pricing">
-                                <span class="car-feature">Available</span>
-                                <span class="price-note">· Free cancellation</span>
+                        <div class="swiper-slide">
+                            <div class="car-card" style="opacity: 1">
+                                <div class="car-image">
+                                    <img src="images/CalmaAygo.jpg" alt="Toyota Aygo" title="Photo of Toyota Aygo" loading="lazy" width="300" height="200">
+                                </div>
+                                <div class="car-details">
+                                    <h3>Toyota Aygo</h3>
+                                    <p>Compact and fuel-efficient, perfect for city driving.</p>
+                                    <div class="car-pricing">
+                                        <span class="car-feature">Available</span>
+                                        <span class="price-note">· Free cancellation</span>
+                                    </div>
+                                    <a href="/" class="btn btn-primary">Book Now</a>
+                                </div>
                             </div>
-                            <a href="/" class="btn btn-primary">Book Now</a>
                         </div>
-                    </div>
-                    
-                    <!-- Car 2 -->
-                    <div class="car-card swiper-slide" style="opacity: 1">
-                        <div class="car-image">
-                            <img src="images/CalmaTiguan.jpg" alt="Volkswagen Tiguan R line" title="Photo of Volkswagen Tiguan R line" loading="lazy" width="300" height="200">
-                        </div>
-                        <div class="car-details">
-                            <h3>Volkswagen Tiguan R line</h3>
-                            <p>Spacious SUV with advanced features for comfort.</p>
-                            <div class="car-pricing">
-                                <span class="car-feature">Available</span>
-                                <span class="price-note">· Free cancellation</span>
+
+                        <!-- Car 2 -->
+                        <div class="swiper-slide">
+                            <div class="car-card" style="opacity: 1">
+                                <div class="car-image">
+                                    <img src="images/CalmaTiguan.jpg" alt="Volkswagen Tiguan R line" title="Photo of Volkswagen Tiguan R line" loading="lazy" width="300" height="200">
+                                </div>
+                                <div class="car-details">
+                                    <h3>Volkswagen Tiguan R line</h3>
+                                    <p>Spacious SUV with advanced features for comfort.</p>
+                                    <div class="car-pricing">
+                                        <span class="car-feature">Available</span>
+                                        <span class="price-note">· Free cancellation</span>
+                                    </div>
+                                    <a href="/" class="btn btn-primary">Book Now</a>
+                                </div>
                             </div>
-                            <a href="/" class="btn btn-primary">Book Now</a>
                         </div>
-                    </div>
-                    
-                    <!-- Car 3 -->
-                    <div class="car-card swiper-slide" style="opacity: 1">
-                        <div class="car-image">
-                            <img src="images/CalmaGolf.jpg" alt="Volkswagen Golf" title="Photo of Volkswagen Golf" loading="lazy" width="300" height="200">
-                        </div>
-                        <div class="car-details">
-                            <h3>Volkswagen Golf</h3>
-                            <p>Versatile hatchback with excellent handling.</p>
-                            <div class="car-pricing">
-                                <span class="car-feature">Available</span>
-                                <span class="price-note">· Free cancellation</span>
+
+                        <!-- Car 3 -->
+                        <div class="swiper-slide">
+                            <div class="car-card" style="opacity: 1">
+                                <div class="car-image">
+                                    <img src="images/CalmaGolf.jpg" alt="Volkswagen Golf" title="Photo of Volkswagen Golf" loading="lazy" width="300" height="200">
+                                </div>
+                                <div class="car-details">
+                                    <h3>Volkswagen Golf</h3>
+                                    <p>Versatile hatchback with excellent handling.</p>
+                                    <div class="car-pricing">
+                                        <span class="car-feature">Available</span>
+                                        <span class="price-note">· Free cancellation</span>
+                                    </div>
+                                    <a href="/" class="btn btn-primary">Book Now</a>
+                                </div>
                             </div>
-                            <a href="/" class="btn btn-primary">Book Now</a>
                         </div>
-                    </div>
-                    
-                    <!-- Car 4 -->
-                    <div class="car-card swiper-slide" style="opacity: 1">
-                        <div class="car-image">
-                            <img src="images/Calmai10.jpg" alt="Hyundai i10" title="Photo of Hyundai i10" loading="lazy" width="300" height="200">
-                        </div>
-                        <div class="car-details">
-                            <h3>Hyundai i10</h3>
-                            <p>Economical and easy to drive mini car.</p>
-                            <div class="car-pricing">
-                                <span class="car-feature">Available</span>
-                                <span class="price-note">· Free cancellation</span>
+
+                        <!-- Car 4 -->
+                        <div class="swiper-slide">
+                            <div class="car-card" style="opacity: 1">
+                                <div class="car-image">
+                                    <img src="images/Calmai10.jpg" alt="Hyundai i10" title="Photo of Hyundai i10" loading="lazy" width="300" height="200">
+                                </div>
+                                <div class="car-details">
+                                    <h3>Hyundai i10</h3>
+                                    <p>Economical and easy to drive mini car.</p>
+                                    <div class="car-pricing">
+                                        <span class="car-feature">Available</span>
+                                        <span class="price-note">· Free cancellation</span>
+                                    </div>
+                                    <a href="/" class="btn btn-primary">Book Now</a>
+                                </div>
                             </div>
-                            <a href="/" class="btn btn-primary">Book Now</a>
                         </div>
-                    </div>
-                    
-                    <!-- Car 5 -->
-                    <div class="car-card swiper-slide" style="opacity: 1">
-                        <div class="car-image">
-                            <img src="images/CalmaCitroen.jpg" alt="Citroen C3" title="Photo of Citroen C3" loading="lazy" width="300" height="200">
-                        </div>
-                        <div class="car-details">
-                            <h3>Citroen C3</h3>
-                            <p>Stylish compact car with excellent comfort.</p>
-                            <div class="car-pricing">
-                                <span class="car-feature">Available</span>
-                                <span class="price-note">· Free cancellation</span>
+
+                        <!-- Car 5 -->
+                        <div class="swiper-slide">
+                            <div class="car-card" style="opacity: 1">
+                                <div class="car-image">
+                                    <img src="images/CalmaCitroen.jpg" alt="Citroen C3" title="Photo of Citroen C3" loading="lazy" width="300" height="200">
+                                </div>
+                                <div class="car-details">
+                                    <h3>Citroen C3</h3>
+                                    <p>Stylish compact car with excellent comfort.</p>
+                                    <div class="car-pricing">
+                                        <span class="car-feature">Available</span>
+                                        <span class="price-note">· Free cancellation</span>
+                                    </div>
+                                    <a href="/" class="btn btn-primary">Book Now</a>
+                                </div>
                             </div>
-                            <a href="/" class="btn btn-primary">Book Now</a>
                         </div>
-                    </div>
-                    
-                    <!-- Car 6 -->
-                    <div class="car-card swiper-slide" style="opacity: 1">
-                        <div class="car-image">
-                            <img src="images/CitroenC3_A.jpg" alt="Citroën C3 rental car" title="Photo of Citroën C3" loading="lazy" width="300" height="200">
-                        </div>
-                        <div class="car-details">
-                            <h3>Citroën C3</h3>
-                            <p>Stylish compact car with excellent comfort.</p>
-                            <div class="car-pricing">
-                                <span class="car-feature">Available</span>
-                                <span class="price-note">· Free cancellation</span>
+
+                        <!-- Car 6 -->
+                        <div class="swiper-slide">
+                            <div class="car-card" style="opacity: 1">
+                                <div class="car-image">
+                                    <img src="images/CitroenC3_A.jpg" alt="Citroën C3 rental car" title="Photo of Citroën C3" loading="lazy" width="300" height="200">
+                                </div>
+                                <div class="car-details">
+                                    <h3>Citroën C3</h3>
+                                    <p>Stylish compact car with excellent comfort.</p>
+                                    <div class="car-pricing">
+                                        <span class="car-feature">Available</span>
+                                        <span class="price-note">· Free cancellation</span>
+                                    </div>
+                                    <a href="/" class="btn btn-primary">Book Now</a>
+                                </div>
                             </div>
-                            <a href="/" class="btn btn-primary">Book Now</a>
+                        </div>
+
+                        <!-- Car 7 -->
+                        <div class="swiper-slide">
+                            <div class="car-card" style="opacity: 1">
+                                <div class="car-image">
+                                    <img src="images/CalmaSuzuki.jpg" alt="Suzuki Celerio" title="Photo of Suzuki Celerio" loading="lazy" width="300" height="200">
+                                </div>
+                                <div class="car-details">
+                                    <h3>Suzuki Celerio</h3>
+                                    <p>Sporty and nimble, ideal for exploring Crete.</p>
+                                    <div class="car-pricing">
+                                        <span class="car-feature">Available</span>
+                                        <span class="price-note">· Free cancellation</span>
+                                    </div>
+                                    <a href="/" class="btn btn-primary">Book Now</a>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Car 8 -->
+                        <div class="swiper-slide">
+                            <div class="car-card" style="opacity: 1">
+                                <div class="car-image">
+                                    <img src="images/CalmaFiatPanda.jpg" alt="Fiat Panda" title="Photo of Fiat Panda" loading="lazy" width="300" height="200">
+                                </div>
+                                <div class="car-details">
+                                    <h3>Fiat Panda</h3>
+                                    <p>Reliable compact car for all types of journeys.</p>
+                                    <div class="car-pricing">
+                                        <span class="car-feature">Available</span>
+                                        <span class="price-note">· Free cancellation</span>
+                                    </div>
+                                    <a href="/" class="btn btn-primary">Book Now</a>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Car 9 -->
+                        <div class="swiper-slide">
+                            <div class="car-card" style="opacity: 1">
+                                <div class="car-image">
+                                    <img src="images/CalmaAudiA3.jpg" alt="Audi A3" title="Photo of Audi A3" loading="lazy" width="300" height="200">
+                                </div>
+                                <div class="car-details">
+                                    <h3>Audi A3</h3>
+                                    <p>Stylish and comfortable for luxury travel.</p>
+                                    <div class="car-pricing">
+                                        <span class="car-feature">Available</span>
+                                        <span class="price-note">· Free cancellation</span>
+                                    </div>
+                                    <a href="/" class="btn btn-primary">Book Now</a>
+                                </div>
+                            </div>
                         </div>
                     </div>
 
-                    <!-- Car 7 -->
-                    <div class="car-card swiper-slide" style="opacity: 1">
-                        <div class="car-image">
-                            <img src="images/CalmaSuzuki.jpg" alt="Suzuki Celerio" title="Photo of Suzuki Celerio" loading="lazy" width="300" height="200">
-                        </div>
-                        <div class="car-details">
-                            <h3>Suzuki Celerio</h3>
-                            <p>Sporty and nimble, ideal for exploring Crete.</p>
-                            <div class="car-pricing">
-                                <span class="car-feature">Available</span>
-                                <span class="price-note">· Free cancellation</span>
-                            </div>
-                            <a href="/" class="btn btn-primary">Book Now</a>
-                        </div>
-                    </div>
-
-                    <!-- Car 8 -->
-                    <div class="car-card swiper-slide" style="opacity: 1">
-                        <div class="car-image">
-                            <img src="images/CalmaFiatPanda.jpg" alt="Fiat Panda" title="Photo of Fiat Panda" loading="lazy" width="300" height="200">
-                        </div>
-                        <div class="car-details">
-                            <h3>Fiat Panda</h3>
-                            <p>Reliable compact car for all types of journeys.</p>
-                            <div class="car-pricing">
-                                <span class="car-feature">Available</span>
-                                <span class="price-note">· Free cancellation</span>
-                            </div>
-                            <a href="/" class="btn btn-primary">Book Now</a>
-                        </div>
-                    </div>
-
-                    <!-- Car 9 -->
-                    <div class="car-card swiper-slide" style="opacity: 1">
-                        <div class="car-image">
-                            <img src="images/CalmaAudiA3.jpg" alt="Audi A3" title="Photo of Audi A3" loading="lazy" width="300" height="200">
-                        </div>
-                        <div class="car-details">
-                            <h3>Audi A3</h3>
-                            <p>Stylish and comfortable for luxury travel.</p>
-                            <div class="car-pricing">
-                                <span class="car-feature">Available</span>
-                                <span class="price-note">· Free cancellation</span>
-                            </div>
-                            <a href="/" class="btn btn-primary">Book Now</a>
-                        </div>
-                    </div>
-                    </div>
-                    <div class="swiper-button-prev" aria-label="Previous cars"></div>
-                    <div class="swiper-button-next" aria-label="Next cars"></div>
-                    <div class="swiper-pagination"></div>
-                    </div>
+                    <!-- Arrows -->
+                    <div class="swiper-button-prev" aria-label="Previous"></div>
+                    <div class="swiper-button-next" aria-label="Next"></div>
+                    <!-- Dots -->
+                    <div class="swiper-pagination" aria-label="Carousel Pagination"></div>
                 </div>
             </div>
         </section>
@@ -1514,30 +1533,31 @@
     <script src="assets/js/mobile-menu.js"></script>
 
     <script>
-        document.addEventListener('DOMContentLoaded', function () {
-            const sliderEl = document.querySelector('.our-fleet-slider .swiper');
-            if (sliderEl) {
-                const slider = new Swiper('.our-fleet-slider .swiper', {
-                    roundLengths: true,
-                    watchSlidesProgress: true,
-                    rewind: true,
-                    loop: false,
-                    // IMPORTANT: remove JS offsets to avoid sub-pixel rounding on iOS
-                    slidesOffsetBefore: 0,
-                    slidesOffsetAfter: 0,
-                    pagination: { el: '.our-fleet-slider .swiper-pagination', clickable: true },
-                    navigation: { nextEl: '.our-fleet-slider .swiper-button-next', prevEl: '.our-fleet-slider .swiper-button-prev' },
-                    breakpoints: {
-                        // Mobile: no centered slides (prevents iOS drift), 1 slide per view
-                        0:    { slidesPerView: 1, centeredSlides: false, centeredSlidesBounds: false, spaceBetween: 16 },
-                        // Tablet: 2 per view
-                        768:  { slidesPerView: 2, centeredSlides: false, centeredSlidesBounds: false, spaceBetween: 24 },
-                        // Desktop: 4 per view
-                        1200: { slidesPerView: 4, centeredSlides: false, centeredSlidesBounds: false, spaceBetween: 24 }
-                    }
-                });
-            }
+      (function () {
+        const swiper = new Swiper('.our-fleet-swiper', {
+          centeredSlides: true,
+          watchOverflow: true,
+          initialSlide: 0,
+          speed: 400,
+          simulateTouch: true,
+          resistanceRatio: 0,
+          touchStartPreventDefault: false,
+          pagination: {
+            el: '.our-fleet-swiper .swiper-pagination',
+            clickable: true,
+          },
+          navigation: {
+            nextEl: '.our-fleet-swiper .swiper-button-next',
+            prevEl: '.our-fleet-swiper .swiper-button-prev',
+          },
+          breakpoints: {
+            0: { slidesPerView: 1.1, spaceBetween: 12 },
+            768: { slidesPerView: 2, spaceBetween: 16 },
+            1024: { slidesPerView: 3, spaceBetween: 20 },
+          },
+          autoHeight: false,
         });
+      })();
     </script>
     
     <!-- FAQ Accordion Script -->


### PR DESCRIPTION
## Summary
- replace custom fleet slider with Swiper carousel
- add responsive centered slides with navigation and pagination
- streamline fleet slider styles for iOS

## Testing
- `npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_68a5860e56c483328a2656cb11aa7393