### PR TITLE
Enhance fleet slider with autoplay and navigation fix

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2387,10 +2387,19 @@ select#pickup-location, select#dropoff-location {
 .our-fleet-swiper .swiper-slide {
     display: flex;
     justify-content: center;
+    flex-shrink: 0;
 }
 /* Ensure cards don’t stretch oddly */
 .our-fleet-swiper .swiper-slide > * {
     max-width: 100%;
+}
+/* Smooth card hover/active effects */
+.our-fleet-swiper .swiper-slide .car-card {
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+.our-fleet-swiper .swiper-slide-active .car-card {
+    transform: scale(1.03);
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
 }
 /* Improve iOS smoothness */
 .our-fleet-swiper,

--- a/index.html
+++ b/index.html
@@ -1534,22 +1534,17 @@
 
     <script>
       document.addEventListener('DOMContentLoaded', () => {
-        const totalSlides = document.querySelectorAll('.our-fleet-swiper .swiper-slide').length;
-
         const swiper = new Swiper('.our-fleet-swiper', {
-          // Make it circular and fill the left side with clones
           loop: true,
-          loopAdditionalSlides: Math.max(6, totalSlides), // enough clones so no blank edges
-          loopedSlides: totalSlides, // loop through all cars
-          loopPreventsSliding: false,
-          slidesPerGroup: 1,
-
-          // Keep the centered 3-cards layout
           centeredSlides: true,
-          initialSlide: 0, // Toyota Aygo centered on load
-          speed: 400,
+          speed: 600,
+          grabCursor: true,
+          autoplay: {
+            delay: 5000,
+            disableOnInteraction: false,
+            pauseOnMouseEnter: true,
+          },
 
-          // UI (leave your selectors as-is)
           pagination: {
             el: '.our-fleet-swiper .swiper-pagination',
             clickable: true,
@@ -1558,15 +1553,11 @@
             nextEl: '.our-fleet-swiper .swiper-button-next',
             prevEl: '.our-fleet-swiper .swiper-button-prev',
           },
-
-          // Responsive
           breakpoints: {
             0:    { slidesPerView: 1.1, spaceBetween: 12 },
             768:  { slidesPerView: 2,   spaceBetween: 16 },
             1024: { slidesPerView: 3,   spaceBetween: 20 }
           },
-
-          // iOS/Touch stability
           simulateTouch: true,
           resistanceRatio: 0,
           touchStartPreventDefault: false,


### PR DESCRIPTION
## Summary
- add grab cursor and autoplay to Our Fleet Swiper for seamless looping
- highlight active car with subtle scale and shadow
- remove extra loop params and keep slides from shrinking to fix arrow navigation

## Testing
- `node tests/dateUtils.test.js`
- `node tests/mobileSidebar.test.js` *(reports unimplemented window.scrollTo, but navigation works)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c10e3e5483328b97fead70009135