### PR TITLE
Align country selector size with license expiry field and add placeholders

### DIFF
--- a/personal-info.html
+++ b/personal-info.html
@@ -708,7 +708,7 @@
     /* Select2 custom styling */
     .select2-container--default .select2-selection--single {
       height: auto;
-      padding: 0.6rem 0.8rem;
+      padding: 0.9rem 1rem;
       border: 1px solid #ddd;
       border-radius: 6px;
       background-color: #f9f9f9;
@@ -1195,19 +1195,19 @@
         <div class="form-grid">
           <div class="form-group">
             <label class="required">First Name</label>
-            <input type="text" id="firstName" name="firstName" required>
+            <input type="text" id="firstName" name="firstName" placeholder="First Name" required>
             <div id="firstName-error" class="validation-message"></div>
           </div>
           
           <div class="form-group">
             <label class="required">Last Name</label>
-            <input type="text" id="lastName" name="lastName" required>
+            <input type="text" id="lastName" name="lastName" placeholder="Last Name" required>
             <div id="lastName-error" class="validation-message"></div>
           </div>
           
           <div class="form-group">
             <label class="required">Email Address</label>
-            <input type="email" id="email" name="email" required>
+            <input type="email" id="email" name="email" placeholder="Email Address" required>
             <div id="email-error" class="validation-message"></div>
           </div>
           
@@ -1222,14 +1222,14 @@
           
           <div class="form-group">
             <label class="required">Age</label>
-            <input type="number" id="age" name="age" min="25" max="99" required>
+            <input type="number" id="age" name="age" min="25" max="99" placeholder="25+" required>
             <div id="age-error" class="validation-message"></div>
             <div class="hint">You must be at least 25 years old to rent a car.</div>
           </div>
           
           <div class="form-group">
             <label class="required">Driver's License Number</label>
-            <input type="text" id="driverLicense" name="driverLicense">
+            <input type="text" id="driverLicense" name="driverLicense" placeholder="Driver's License Number">
             <div id="driverLicense-error" class="validation-message"></div>
           </div>
           


### PR DESCRIPTION
## Summary
- match Select2 country selector padding to license expiry input for consistent sizing
- add descriptive placeholders to personal information inputs

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a71104bb14833293f9faa930c0f2a4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a step-by-step progress tracker above the form, highlighting the current “Personal Info” step.
  * Introduced input placeholders for First Name, Last Name, Email Address, Age, and Driver’s License Number to guide entry.
  * Added a dedicated validation message area for the License Expiration Date for clearer error feedback.
  * No changes to server interactions or public APIs.

* Style
  * Increased padding for single-select dropdowns to improve spacing and tap targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->